### PR TITLE
Fix sidebar warning from asChild prop

### DIFF
--- a/Layout.tsx
+++ b/Layout.tsx
@@ -68,11 +68,10 @@ export default function Layout({ children, currentPageName }) {
                 <SidebarMenu className="space-y-1">
                   {navigationItems.map((item) => (
                     <SidebarMenuItem key={item.title}>
-                      <SidebarMenuButton 
-                        asChild 
+                      <SidebarMenuButton
                         className={`transition-all duration-300 rounded-xl px-4 py-3 ${
-                          location.pathname === item.url 
-                            ? 'bg-gradient-to-r from-slate-900 to-slate-800 text-white shadow-lg' 
+                          location.pathname === item.url
+                            ? 'bg-gradient-to-r from-slate-900 to-slate-800 text-white shadow-lg'
                             : 'hover:bg-slate-50 text-slate-700 hover:text-slate-900'
                         }`}
                       >

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -18,8 +18,12 @@ export function SidebarGroupLabel({ children, className = '' }: { children: Reac
 export function SidebarMenu({ children, className = '' }: { children: React.ReactNode; className?: string }) {
   return <div className={className}>{children}</div>;
 }
-export function SidebarMenuButton({ children, className = '', ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean }) {
-  return <button className={className} {...props}>{children}</button>;
+export function SidebarMenuButton({ children, className = '', ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button className={className} {...props}>
+      {children}
+    </button>
+  );
 }
 export function SidebarMenuItem({ children, className = '' }: { children: React.ReactNode; className?: string }) {
   return <div className={className}>{children}</div>;


### PR DESCRIPTION
## Summary
- drop unused `asChild` prop from `SidebarMenuButton`
- remove `asChild` usage in `Layout`

This prevents React from warning about the unknown `asChild` attribute during development.

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bdd0470a48320b08541a828dc4113