### PR TITLE
Add JSON import functionality to admin panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,26 @@ And preview it with:
 npm run preview
 ```
 
+## JSON Import
+
+You can bulk add timeline entries by uploading a JSON file in the Admin panel.
+The file must follow this structure:
+
+```json
+{
+  "entries": [
+    {
+      "title": "Event title",
+      "description": "Optional description",
+      "date": "YYYY-MM-DD",
+      "precision": "year|month|day|hour"
+    }
+  ]
+}
+```
+
+An example file is provided at `import-example.json`.
+
 ## Environment
 
 This project uses a local SQLite database managed by Prisma. An example

--- a/components/admin/ImportEntries.tsx
+++ b/components/admin/ImportEntries.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Upload } from "lucide-react";
+import { TimelineEntry } from "@/entities/TimelineEntry";
+
+export default function ImportEntries({ onImported }) {
+  const [file, setFile] = useState<File | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files && e.target.files[0];
+    setFile(f || null);
+  };
+
+  const handleImport = async () => {
+    if (!file) return;
+    setIsLoading(true);
+    try {
+      const text = await file.text();
+      const json = JSON.parse(text);
+      if (!Array.isArray(json.entries)) throw new Error("Invalid format");
+      await TimelineEntry.bulkCreate(json.entries);
+      if (onImported) onImported();
+      setFile(null);
+    } catch (err) {
+      console.error("Import failed", err);
+    }
+    setIsLoading(false);
+  };
+
+  return (
+    <Card className="bg-white/90 backdrop-blur-sm border-slate-200/60 shadow-xl mt-8">
+      <CardHeader className="pb-4">
+        <CardTitle className="flex items-center gap-3 text-xl font-bold text-slate-900">
+          <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-green-500 to-emerald-500 flex items-center justify-center">
+            <Upload className="w-5 h-5 text-white" />
+          </div>
+          Import JSON
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <Input type="file" accept="application/json" onChange={handleFileChange} />
+          <Button
+            disabled={!file || isLoading}
+            onClick={handleImport}
+            className="w-full bg-gradient-to-r from-slate-800 to-slate-900 hover:from-slate-900 hover:to-black text-white shadow-lg hover:shadow-xl transition-all duration-300 py-3"
+          >
+            {isLoading ? "Importing..." : "Import"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/entities/TimelineEntry.ts
+++ b/entities/TimelineEntry.ts
@@ -25,4 +25,14 @@ export class TimelineEntry {
     if (!res.ok) throw new Error('Failed to create entry');
     return res.json();
   }
+
+  static async bulkCreate(entries: Omit<TimelineEntryType, 'id' | 'createdAt'>[]): Promise<TimelineEntryType[]> {
+    const res = await fetch(`${API_URL}/bulk`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ entries })
+    });
+    if (!res.ok) throw new Error('Failed to import entries');
+    return res.json();
+  }
 }

--- a/import-example.json
+++ b/import-example.json
@@ -1,0 +1,16 @@
+{
+  "entries": [
+    {
+      "title": "Started Job",
+      "description": "Began new position at company",
+      "date": "2024-05-01",
+      "precision": "day"
+    },
+    {
+      "title": "Graduated University",
+      "description": "Completed computer science degree",
+      "date": "2023-06-15",
+      "precision": "day"
+    }
+  ]
+}

--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { TimelineEntry } from "@/entities/TimelineEntry";
 import { motion } from "framer-motion";
 import EntryForm from "../components/admin/EntryForm";
+import ImportEntries from "../components/admin/ImportEntries";
 import { Settings, Sparkles, Clock, CheckCircle } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
@@ -76,8 +77,9 @@ export default function Admin() {
         )}
 
         <div className="grid lg:grid-cols-3 gap-8">
-          <div className="lg:col-span-2">
+          <div className="lg:col-span-2 space-y-8">
             <EntryForm onSubmit={handleSubmit} isLoading={isLoading} />
+            <ImportEntries onImported={loadRecentEntries} />
           </div>
           
           <div className="space-y-6">

--- a/server/index.js
+++ b/server/index.js
@@ -27,6 +27,28 @@ app.post('/api/entries', async (req, res) => {
   res.json(entry);
 });
 
+app.post('/api/entries/bulk', async (req, res) => {
+  const { entries } = req.body;
+  if (!Array.isArray(entries)) {
+    res.status(400).json({ error: 'Entries array missing' });
+    return;
+  }
+  const created = [];
+  for (const e of entries) {
+    if (!e.title || !e.date || !e.precision) continue;
+    const entry = await prisma.timelineEntry.create({
+      data: {
+        title: e.title,
+        description: e.description || '',
+        date: new Date(e.date),
+        precision: e.precision,
+      }
+    });
+    created.push(entry);
+  }
+  res.json(created);
+});
+
 const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => {
   console.log(`API server listening on port ${PORT}`);


### PR DESCRIPTION
## Summary
- implement server endpoint for bulk timeline entries
- add `bulkCreate` method in TimelineEntry entity
- create ImportEntries component for admin panel
- integrate ImportEntries component into admin page
- document JSON import format and provide example file

## Testing
- `npm run build`
- `node server/index.js` (started and stopped)

------
https://chatgpt.com/codex/tasks/task_e_688ca4a90d408320858f87b710184f58