### PR TITLE
Fix search endpoint error

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -13,8 +13,8 @@ app.get('/api/entries/search', async (req, res) => {
   const entries = await prisma.timelineEntry.findMany({
     where: {
       OR: [
-        { title: { contains: String(query), mode: 'insensitive' } },
-        { description: { contains: String(query), mode: 'insensitive' } }
+        { title: { contains: String(query) } },
+        { description: { contains: String(query) } }
       ]
     },
     orderBy: { date: 'asc' }


### PR DESCRIPTION
## Summary
- remove unsupported `mode: 'insensitive'` flag from the SQLite search query

## Testing
- `npm run build` *(fails: vite permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_688d18c3ba8c8320bf7648e518d0b392