### PR TITLE
feat: support multiple timetables and calendar editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ npm run preview
 ## JSON Import
 
 You can bulk add schedule items by uploading a JSON file in the Admin panel.
-The file must follow this structure:
+The file must specify a timetable and follow this structure:
 
 ```json
 {
+  "timetable": { "name": "My Schedule" },
   "entries": [
     {
       "title": "Event title",

--- a/components/admin/CalendarEditor.tsx
+++ b/components/admin/CalendarEditor.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import { Calendar, dateFnsLocalizer } from 'react-big-calendar';
+import { format, parse, startOfWeek, getDay } from 'date-fns';
+import enUS from 'date-fns/locale/en-US';
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+import { TimelineEntry } from '@/entities/TimelineEntry';
+
+const locales = { 'en-US': enUS };
+const localizer = dateFnsLocalizer({ format, parse, startOfWeek, getDay, locales });
+
+interface Props {
+  timetableId: number | null;
+}
+
+export default function CalendarEditor({ timetableId }: Props) {
+  const [events, setEvents] = useState<any[]>([]);
+
+  const load = async () => {
+    if (!timetableId) return;
+    const data = await TimelineEntry.list(timetableId);
+    setEvents(data.map(e => ({ id: e.id, title: e.title, start: new Date(e.date), end: new Date(e.date) })));
+  };
+
+  useEffect(() => {
+    load();
+  }, [timetableId]);
+
+  const handleSelectSlot = async ({ start }: { start: Date }) => {
+    if (!timetableId) return;
+    const title = window.prompt('Event title');
+    if (!title) return;
+    await TimelineEntry.create({ title, description: '', date: start.toISOString(), precision: 'hour', timetableId });
+    await load();
+  };
+
+  const handleSelectEvent = async (event: any) => {
+    if (window.confirm('Delete this event?')) {
+      await TimelineEntry.delete(event.id);
+      await load();
+    }
+  };
+
+  return (
+    <div className="mt-8">
+      <Calendar
+        localizer={localizer}
+        events={events}
+        defaultView="week"
+        selectable
+        style={{ height: 500 }}
+        onSelectSlot={handleSelectSlot}
+        onSelectEvent={handleSelectEvent}
+      />
+    </div>
+  );
+}

--- a/components/admin/ImportEntries.tsx
+++ b/components/admin/ImportEntries.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Upload } from "lucide-react";
 import { TimelineEntry } from "@/entities/TimelineEntry";
+import { Timetable } from "@/entities/Timetable";
 
 export default function ImportEntries({ onImported }) {
   const [file, setFile] = useState<File | null>(null);
@@ -21,7 +22,13 @@ export default function ImportEntries({ onImported }) {
       const text = await file.text();
       const json = JSON.parse(text);
       if (!Array.isArray(json.entries)) throw new Error("Invalid format");
-      await TimelineEntry.bulkCreate(json.entries);
+      let timetableId = json.timetableId;
+      if (!timetableId && json.timetable?.name) {
+        const t = await Timetable.create(json.timetable.name);
+        timetableId = t.id;
+      }
+      if (!timetableId) throw new Error('No timetable specified');
+      await TimelineEntry.bulkCreate(json.entries, timetableId);
       if (onImported) onImported();
       setFile(null);
     } catch (err) {

--- a/components/admin/TimetableManager.tsx
+++ b/components/admin/TimetableManager.tsx
@@ -1,0 +1,66 @@
+import React, { useState, useEffect } from 'react';
+import { Timetable, TimetableType } from '@/entities/Timetable';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+
+interface Props {
+  value: number | null;
+  onChange: (id: number | null) => void;
+}
+
+export default function TimetableManager({ value, onChange }: Props) {
+  const [timetables, setTimetables] = useState<TimetableType[]>([]);
+  const [newName, setNewName] = useState('');
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const load = async () => {
+    const data = await Timetable.list();
+    setTimetables(data);
+    if (!value && data.length > 0) onChange(data[0].id);
+  };
+
+  const handleCreate = async () => {
+    if (!newName.trim()) return;
+    const t = await Timetable.create(newName.trim());
+    setNewName('');
+    await load();
+    onChange(t.id);
+  };
+
+  const handleDelete = async (id?: number) => {
+    await Timetable.delete(id);
+    await load();
+    if (id && value === id) {
+      onChange(null);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <Select value={value ? String(value) : undefined} onValueChange={(v) => onChange(Number(v))}>
+        <SelectTrigger className="border-slate-200">
+          <SelectValue placeholder="Select timetable" />
+        </SelectTrigger>
+        <SelectContent>
+          {timetables.map((t) => (
+            <SelectItem key={t.id} value={String(t.id)}>
+              {t.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <div className="flex gap-2">
+        <Input value={newName} onChange={(e) => setNewName(e.target.value)} placeholder="New timetable" className="border-slate-200 flex-1" />
+        <Button onClick={handleCreate} className="bg-amber-500 text-white border-amber-600">Create</Button>
+      </div>
+      <div className="flex gap-2">
+        <Button onClick={() => handleDelete(value ?? undefined)} disabled={!value} className="flex-1 bg-red-500 text-white border-red-600 disabled:opacity-50">Delete</Button>
+        <Button onClick={() => handleDelete()} className="flex-1 bg-red-500 text-white border-red-600">Delete All</Button>
+      </div>
+    </div>
+  );
+}

--- a/entities/TimelineEntry.json
+++ b/entities/TimelineEntry.json
@@ -12,35 +12,24 @@
     },
     "date": {
       "type": "string",
-      "format": "date",
+      "format": "date-time",
       "description": "Date of the event"
     },
-    "category": {
+    "precision": {
       "type": "string",
-      "enum": [
-        "milestone",
-        "achievement",
-        "event",
-        "project",
-        "personal"
-      ],
-      "default": "event",
-      "description": "Category of the schedule item"
+      "enum": ["year", "month", "day", "hour"],
+      "default": "day",
+      "description": "Precision of the scheduled date"
     },
-    "importance": {
-      "type": "string",
-      "enum": [
-        "low",
-        "medium",
-        "high",
-        "critical"
-      ],
-      "default": "medium",
-      "description": "Importance level of the entry"
+    "timetableId": {
+      "type": "number",
+      "description": "Identifier of the timetable this entry belongs to"
     }
   },
   "required": [
     "title",
-    "date"
+    "date",
+    "precision",
+    "timetableId"
   ]
 }

--- a/entities/TimelineEntry.ts
+++ b/entities/TimelineEntry.ts
@@ -5,19 +5,21 @@ export interface TimelineEntryType {
   date: string;
   precision: 'year' | 'month' | 'day' | 'hour';
   createdAt: string;
+  timetableId: number;
 }
 
 const API_URL = 'http://localhost:3001/api/entries';
 
 export class TimelineEntry {
-  static async list(): Promise<TimelineEntryType[]> {
-    const res = await fetch(API_URL);
+  static async list(timetableId: number): Promise<TimelineEntryType[]> {
+    const params = new URLSearchParams({ timetableId: String(timetableId) });
+    const res = await fetch(`${API_URL}?${params.toString()}`);
     if (!res.ok) throw new Error('Failed to load entries');
     return res.json();
   }
 
-  static async search(query: string): Promise<TimelineEntryType[]> {
-    const params = new URLSearchParams({ q: query });
+  static async search(query: string, timetableId: number): Promise<TimelineEntryType[]> {
+    const params = new URLSearchParams({ q: query, timetableId: String(timetableId) });
     const res = await fetch(`${API_URL}/search?${params.toString()}`);
     if (!res.ok) throw new Error('Failed to search entries');
     return res.json();
@@ -33,13 +35,18 @@ export class TimelineEntry {
     return res.json();
   }
 
-  static async bulkCreate(entries: Omit<TimelineEntryType, 'id' | 'createdAt'>[]): Promise<TimelineEntryType[]> {
+  static async bulkCreate(entries: Omit<TimelineEntryType, 'id' | 'createdAt'>[], timetableId: number): Promise<TimelineEntryType[]> {
     const res = await fetch(`${API_URL}/bulk`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ entries })
+      body: JSON.stringify({ entries, timetableId })
     });
     if (!res.ok) throw new Error('Failed to import entries');
     return res.json();
+  }
+
+  static async delete(id: number): Promise<void> {
+    const res = await fetch(`${API_URL}/${id}`, { method: 'DELETE' });
+    if (!res.ok) throw new Error('Failed to delete entry');
   }
 }

--- a/entities/Timetable.ts
+++ b/entities/Timetable.ts
@@ -1,0 +1,30 @@
+export interface TimetableType {
+  id: number;
+  name: string;
+}
+
+const API_URL = 'http://localhost:3001/api/timetables';
+
+export class Timetable {
+  static async list(): Promise<TimetableType[]> {
+    const res = await fetch(API_URL);
+    if (!res.ok) throw new Error('Failed to load timetables');
+    return res.json();
+  }
+
+  static async create(name: string): Promise<TimetableType> {
+    const res = await fetch(API_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name })
+    });
+    if (!res.ok) throw new Error('Failed to create timetable');
+    return res.json();
+  }
+
+  static async delete(id?: number): Promise<void> {
+    const url = id ? `${API_URL}/${id}` : API_URL;
+    const res = await fetch(url, { method: 'DELETE' });
+    if (!res.ok) throw new Error('Failed to delete timetable');
+  }
+}

--- a/import-example.json
+++ b/import-example.json
@@ -1,4 +1,5 @@
 {
+  "timetable": { "name": "Sample Schedule" },
   "entries": [
     {
       "title": "Started Job",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "lucide-react": "^0.370.0",
         "prisma": "^6.13.0",
         "react": "^18.2.0",
+        "react-big-calendar": "^1.11.4",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.23.0"
       },
@@ -271,6 +272,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -751,6 +761,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@prisma/client": {
       "version": "6.13.0",
       "resolved": "https://registry.npmmirror.com/@prisma/client/-/client-6.13.0.tgz",
@@ -837,6 +857,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@restart/hooks": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
+      "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1194,14 +1226,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1217,6 +1247,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/warning": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
+      "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1416,6 +1452,15 @@
         "consola": "^3.2.3"
       }
     },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/confbox": {
       "version": "0.2.2",
       "resolved": "https://registry.npmmirror.com/confbox/-/confbox-0.2.2.tgz",
@@ -1494,7 +1539,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/date-arithmetic": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-arithmetic/-/date-arithmetic-4.1.0.tgz",
+      "integrity": "sha512-QWxYLR5P/6GStZcdem+V1xoto6DMadYWpMXU82ES3/RfR3Wdwr3D0+be7mgOJ+Ov0G9D5Dmb9T17sNLQYj9XOg==",
       "license": "MIT"
     },
     "node_modules/date-fns": {
@@ -1506,6 +1556,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -1548,11 +1604,30 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmmirror.com/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
       "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -1938,6 +2013,11 @@
         "giget": "dist/cli.mjs"
       }
     },
+    "node_modules/globalize": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/globalize/-/globalize-0.1.1.tgz",
+      "integrity": "sha512-5e01v8eLGfuQSOvx2MsDMOWS0GFtCx1wPzQSmcHw4hkxFzrQDBO3Xwg/m8Hr/7qXMrHeOIE29qWVzyv06u1TZA=="
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmmirror.com/gopd/-/gopd-1.2.0.tgz",
@@ -2047,6 +2127,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmmirror.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -2103,6 +2192,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -2134,6 +2235,15 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2151,6 +2261,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -2183,6 +2299,27 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/motion-dom": {
@@ -2458,6 +2595,17 @@
         }
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmmirror.com/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2548,6 +2696,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-big-calendar": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/react-big-calendar/-/react-big-calendar-1.19.4.tgz",
+      "integrity": "sha512-FrvbDx2LF6JAWFD96LU1jjloppC5OgIvMYUYIPzAw5Aq+ArYFPxAjLqXc4DyxfsQDN0TJTMuS/BIbcSB7Pg0YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "clsx": "^1.2.1",
+        "date-arithmetic": "^4.1.0",
+        "dayjs": "^1.11.7",
+        "dom-helpers": "^5.2.1",
+        "globalize": "^0.1.1",
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "luxon": "^3.2.1",
+        "memoize-one": "^6.0.0",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.40",
+        "prop-types": "^15.8.1",
+        "react-overlays": "^5.2.1",
+        "uncontrollable": "^7.2.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.14.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -2559,6 +2735,38 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
+    },
+    "node_modules/react-overlays": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
+      "integrity": "sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.8",
+        "@popperjs/core": "^2.11.6",
+        "@restart/hooks": "^0.4.7",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
       }
     },
     "node_modules/react-refresh": {
@@ -2980,6 +3188,21 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uncontrollable": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": ">=16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0"
+      }
+    },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
       "resolved": "https://registry.npmmirror.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
@@ -3109,6 +3332,15 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "framer-motion": "^11.0.0",
     "lucide-react": "^0.370.0",
     "prisma": "^6.13.0",
+    "react-big-calendar": "^1.11.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.23.0"

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -6,6 +6,7 @@ import { motion } from "framer-motion";
 import TimelineEntryComponent from "../components/timeline/TimelineEntry";
 import TimelineLine from "../components/timeline/TimelineLine";
 import { Calendar, TrendingUp } from "lucide-react";
+import TimetableManager from "../components/admin/TimetableManager";
 
 export default function Schedule() {
   const [entries, setEntries] = useState([]);
@@ -14,18 +15,20 @@ export default function Schedule() {
   const containerRef = useRef<HTMLDivElement>(null);
   const [scrollTop, setScrollTop] = useState(0);
   const [containerHeight, setContainerHeight] = useState(0);
+  const [timetableId, setTimetableId] = useState<number | null>(null);
 
   useEffect(() => {
-    loadEntries();
+    if (timetableId) loadEntries();
     if (containerRef.current) {
       setContainerHeight(containerRef.current.clientHeight);
     }
-  }, []);
+  }, [timetableId]);
 
   const loadEntries = async () => {
     setIsLoading(true);
     try {
-      const data = await TimelineEntry.list();
+      if (!timetableId) return;
+      const data = await TimelineEntry.list(timetableId);
       setEntries(data);
     } catch (error) {
       console.error("Error loading schedule entries:", error);
@@ -36,7 +39,8 @@ export default function Schedule() {
   const searchEntries = async (query: string) => {
     setIsLoading(true);
     try {
-      const data = await TimelineEntry.search(query);
+      if (!timetableId) return;
+      const data = await TimelineEntry.search(query, timetableId);
       setEntries(data);
     } catch (error) {
       console.error('Error searching schedule entries:', error);
@@ -81,7 +85,7 @@ export default function Schedule() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-amber-50">
       <div className="max-w-7xl mx-auto px-6 py-12">
-        <motion.div 
+        <motion.div
           initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
@@ -98,6 +102,10 @@ export default function Schedule() {
             <p className="text-xl text-slate-600 max-w-2xl mx-auto leading-relaxed">
               Plan your week and view each day with an intuitive schedule and clear visualizations
             </p>
+
+          <div className="max-w-md mx-auto mt-8">
+            <TimetableManager value={timetableId} onChange={setTimetableId} />
+          </div>
 
           {entries.length > 0 && (
             <div className="flex items-center justify-center gap-6 mt-8">

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,11 +10,19 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model Timetable {
+  id      Int             @id @default(autoincrement())
+  name    String
+  entries TimelineEntry[]
+}
+
 model TimelineEntry {
-  id         Int      @id @default(autoincrement())
-  title      String
+  id          Int       @id @default(autoincrement())
+  title       String
   description String
-  date       DateTime
-  precision  String
-  createdAt  DateTime @default(now())
+  date        DateTime
+  precision   String
+  createdAt   DateTime  @default(now())
+  timetable   Timetable @relation(fields: [timetableId], references: [id])
+  timetableId Int
 }


### PR DESCRIPTION
## Summary
- add Timetable model with Prisma and expose CRUD routes
- allow importing and managing schedules per timetable
- provide calendar-style editor and timetable selector UI

## Testing
- `npx prisma db push`
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688ea3b1db688320bc135057b542507f