### PR TITLE
feat: add minute precision and deletion safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The file must specify a timetable and follow this structure:
       "title": "Event title",
       "description": "Optional description",
       "date": "YYYY-MM-DD",
-      "precision": "year|month|day|hour"
+      "precision": "year|month|day|hour|minute"
     }
   ]
 }

--- a/components/admin/CalendarEditor.tsx
+++ b/components/admin/CalendarEditor.tsx
@@ -29,7 +29,7 @@ export default function CalendarEditor({ timetableId }: Props) {
     if (!timetableId) return;
     const title = window.prompt('Event title');
     if (!title) return;
-    await TimelineEntry.create({ title, description: '', date: start.toISOString(), precision: 'hour', timetableId });
+    await TimelineEntry.create({ title, description: '', date: start.toISOString(), precision: 'minute', timetableId });
     await load();
   };
 
@@ -47,6 +47,8 @@ export default function CalendarEditor({ timetableId }: Props) {
         events={events}
         defaultView="week"
         selectable
+        step={15}
+        timeslots={4}
         style={{ height: 500 }}
         onSelectSlot={handleSelectSlot}
         onSelectEvent={handleSelectEvent}

--- a/components/admin/EntryForm.tsx
+++ b/components/admin/EntryForm.tsx
@@ -31,9 +31,12 @@ export default function EntryForm({ onSubmit, isLoading }) {
     setFormData(prev => ({ ...prev, [field]: value }));
   };
 
-  const dateInputType = formData.precision === "hour" ? "datetime-local" :
+  const dateInputType = formData.precision === "hour" || formData.precision === "minute" ? "datetime-local" :
     formData.precision === "day" ? "date" :
     formData.precision === "month" ? "month" : "number";
+
+  const step = formData.precision === "hour" ? 3600 :
+    formData.precision === "minute" ? 60 : undefined;
 
   return (
     <motion.div
@@ -75,6 +78,7 @@ export default function EntryForm({ onSubmit, isLoading }) {
                 <Input
                   id="date"
                   type={dateInputType}
+                  step={step}
                   value={formData.date}
                   onChange={(e) => handleChange("date", e.target.value)}
                   required
@@ -94,6 +98,7 @@ export default function EntryForm({ onSubmit, isLoading }) {
                   <SelectItem value="month">Month</SelectItem>
                   <SelectItem value="day">Day</SelectItem>
                   <SelectItem value="hour">Hour</SelectItem>
+                  <SelectItem value="minute">Minute</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/components/admin/TimetableManager.tsx
+++ b/components/admin/TimetableManager.tsx
@@ -12,6 +12,7 @@ interface Props {
 export default function TimetableManager({ value, onChange }: Props) {
   const [timetables, setTimetables] = useState<TimetableType[]>([]);
   const [newName, setNewName] = useState('');
+  const [confirmDelete, setConfirmDelete] = useState<{ id?: number; countdown: number } | null>(null);
 
   useEffect(() => {
     load();
@@ -39,6 +40,23 @@ export default function TimetableManager({ value, onChange }: Props) {
     }
   };
 
+  useEffect(() => {
+    if (!confirmDelete) return;
+    if (confirmDelete.countdown <= 0) {
+      handleDelete(confirmDelete.id);
+      setConfirmDelete(null);
+      return;
+    }
+    const timer = setTimeout(() => {
+      setConfirmDelete((c) => (c ? { ...c, countdown: c.countdown - 1 } : null));
+    }, 1000);
+    return () => clearTimeout(timer);
+  }, [confirmDelete]);
+
+  const initiateDelete = (id?: number) => {
+    setConfirmDelete({ id, countdown: 5 });
+  };
+
   return (
     <div className="space-y-2">
       <Select value={value ? String(value) : undefined} onValueChange={(v) => onChange(Number(v))}>
@@ -58,9 +76,16 @@ export default function TimetableManager({ value, onChange }: Props) {
         <Button onClick={handleCreate} className="bg-amber-500 text-white border-amber-600">Create</Button>
       </div>
       <div className="flex gap-2">
-        <Button onClick={() => handleDelete(value ?? undefined)} disabled={!value} className="flex-1 bg-red-500 text-white border-red-600 disabled:opacity-50">Delete</Button>
-        <Button onClick={() => handleDelete()} className="flex-1 bg-red-500 text-white border-red-600">Delete All</Button>
+        <Button onClick={() => initiateDelete(value ?? undefined)} disabled={!value} className="flex-1 bg-red-500 text-white border-red-600 disabled:opacity-50">Delete</Button>
+        <Button onClick={() => initiateDelete()} className="flex-1 bg-red-500 text-white border-red-600">Delete All</Button>
       </div>
+      {confirmDelete && (
+        <div className="flex items-center gap-2 text-sm text-red-700">
+          <span>Deleting in {confirmDelete.countdown}...</span>
+          <Button onClick={async () => { await handleDelete(confirmDelete.id); setConfirmDelete(null); }} className="bg-red-500 text-white border-red-600">Confirm now</Button>
+          <Button onClick={() => setConfirmDelete(null)} className="border-slate-200">Cancel</Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/timeline/TimelineEntry.tsx
+++ b/components/timeline/TimelineEntry.tsx
@@ -14,6 +14,8 @@ function formatEntryDate(dateStr: string, precision: string) {
     case 'day':
       return format(date, 'MMMM d, yyyy');
     case 'hour':
+      return format(date, 'MMMM d, yyyy HH:00');
+    case 'minute':
       return format(date, 'MMMM d, yyyy HH:mm');
     default:
       return format(date, 'MMMM d, yyyy');

--- a/entities/TimelineEntry.json
+++ b/entities/TimelineEntry.json
@@ -17,7 +17,7 @@
     },
     "precision": {
       "type": "string",
-      "enum": ["year", "month", "day", "hour"],
+      "enum": ["year", "month", "day", "hour", "minute"],
       "default": "day",
       "description": "Precision of the scheduled date"
     },

--- a/entities/TimelineEntry.ts
+++ b/entities/TimelineEntry.ts
@@ -3,7 +3,7 @@ export interface TimelineEntryType {
   title: string;
   description: string;
   date: string;
-  precision: 'year' | 'month' | 'day' | 'hour';
+  precision: 'year' | 'month' | 'day' | 'hour' | 'minute';
   createdAt: string;
   timetableId: number;
 }


### PR DESCRIPTION
## Summary
- allow minute-level schedule precision across forms and timeline
- add 15-minute calendar slots
- require countdown confirmation before deleting timetables

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ebfb4840083208085698829fe5481