### PR TITLE
Add dark mode theme and time format settings

### DIFF
--- a/Layout.tsx
+++ b/Layout.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { Link, useLocation } from "react-router-dom";
 import { createPageUrl } from "@/utils";
-import { Clock, Settings, History } from "lucide-react";
+import { Clock, Settings, History, Cog } from "lucide-react";
 import {
   Sidebar,
   SidebarContent,
@@ -28,6 +28,11 @@ const navigationItems = [
     url: createPageUrl("Admin"),
     icon: Settings,
   },
+  {
+    title: "Settings",
+    url: createPageUrl("Settings"),
+    icon: Cog,
+  },
 ];
 
 export default function Layout({ children, currentPageName }) {
@@ -35,7 +40,7 @@ export default function Layout({ children, currentPageName }) {
 
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-gradient-to-br from-slate-50 via-white to-amber-50">
+      <div className="min-h-screen flex w-full bg-gradient-to-br from-slate-50 via-white to-amber-50 dark:from-slate-900 dark:via-slate-900 dark:to-slate-800">
         <style>{`
           :root {
             --primary-navy: #1e293b;
@@ -46,22 +51,22 @@ export default function Layout({ children, currentPageName }) {
           }
         `}</style>
         
-        <Sidebar className="border-r border-slate-200/60 bg-white/80 backdrop-blur-xl">
-          <SidebarHeader className="border-b border-slate-200/60 p-6">
+        <Sidebar className="border-r border-slate-200/60 bg-white/80 backdrop-blur-xl dark:border-slate-700/60 dark:bg-slate-800/80">
+          <SidebarHeader className="border-b border-slate-200/60 p-6 dark:border-slate-700/60">
             <div className="flex items-center gap-3">
               <div className="w-10 h-10 bg-gradient-to-br from-slate-800 to-slate-900 rounded-xl flex items-center justify-center shadow-lg">
                 <Clock className="w-6 h-6 text-amber-400" />
               </div>
               <div>
-                <h2 className="font-bold text-slate-900 text-lg">Chronos</h2>
-                <p className="text-xs text-slate-500 font-medium">Daily Schedule</p>
+                <h2 className="font-bold text-slate-900 text-lg dark:text-slate-100">Chronos</h2>
+                <p className="text-xs text-slate-500 font-medium dark:text-slate-400">Daily Schedule</p>
               </div>
             </div>
           </SidebarHeader>
           
           <SidebarContent className="p-3">
             <SidebarGroup>
-              <SidebarGroupLabel className="text-xs font-semibold text-slate-600 uppercase tracking-wider px-3 py-3">
+              <SidebarGroupLabel className="text-xs font-semibold text-slate-600 uppercase tracking-wider px-3 py-3 dark:text-slate-300">
                 Navigation
               </SidebarGroupLabel>
               <SidebarGroupContent>
@@ -71,8 +76,8 @@ export default function Layout({ children, currentPageName }) {
                       <SidebarMenuButton
                         className={`transition-all duration-300 rounded-xl px-4 py-3 ${
                           location.pathname === item.url
-                            ? 'bg-gradient-to-r from-slate-900 to-slate-800 text-white shadow-lg'
-                            : 'hover:bg-slate-50 text-slate-700 hover:text-slate-900'
+                            ? 'bg-gradient-to-r from-slate-900 to-slate-800 text-white shadow-lg dark:from-slate-700 dark:to-slate-600'
+                            : 'hover:bg-slate-50 text-slate-700 hover:text-slate-900 dark:hover:bg-slate-700 dark:text-slate-300 dark:hover:text-white'
                         }`}
                       >
                         <Link to={item.url} className="flex items-center gap-3">
@@ -89,10 +94,10 @@ export default function Layout({ children, currentPageName }) {
         </Sidebar>
 
         <main className="flex-1 flex flex-col">
-          <header className="bg-white/60 backdrop-blur-xl border-b border-slate-200/60 px-6 py-4 md:hidden">
+          <header className="bg-white/60 backdrop-blur-xl border-b border-slate-200/60 px-6 py-4 md:hidden dark:bg-slate-900/60 dark:border-slate-700/60">
             <div className="flex items-center gap-4">
-              <SidebarTrigger className="hover:bg-slate-100 p-2 rounded-xl transition-colors duration-200" />
-              <h1 className="text-xl font-bold text-slate-900">Chronos</h1>
+              <SidebarTrigger className="hover:bg-slate-100 p-2 rounded-xl transition-colors duration-200 dark:hover:bg-slate-700" />
+              <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">Chronos</h1>
             </div>
           </header>
 

--- a/components/timeline/TimelineEntry.tsx
+++ b/components/timeline/TimelineEntry.tsx
@@ -3,26 +3,28 @@ import { motion } from "framer-motion";
 import { Card, CardContent } from "@/components/ui/card";
 import { Calendar } from "lucide-react";
 import { format, parseISO } from "date-fns";
-
-function formatEntryDate(dateStr: string, precision: string) {
-  const date = parseISO(dateStr);
-  switch (precision) {
-    case 'year':
-      return format(date, 'yyyy');
-    case 'month':
-      return format(date, 'MMMM yyyy');
-    case 'day':
-      return format(date, 'MMMM d, yyyy');
-    case 'hour':
-      return format(date, 'MMMM d, yyyy HH:00');
-    case 'minute':
-      return format(date, 'MMMM d, yyyy HH:mm');
-    default:
-      return format(date, 'MMMM d, yyyy');
-  }
-}
+import { useSettings } from "@/src/SettingsContext";
 
 export default function TimelineEntry({ entry, position, isLeft }) {
+  const { timeFormat } = useSettings();
+
+  const formatEntryDate = (dateStr: string, precision: string) => {
+    const date = parseISO(dateStr);
+    switch (precision) {
+      case 'year':
+        return format(date, 'yyyy');
+      case 'month':
+        return format(date, 'MMMM yyyy');
+      case 'day':
+        return format(date, 'MMMM d, yyyy');
+      case 'hour':
+        return format(date, timeFormat === '12h' ? 'MMMM d, yyyy hh:00 a' : 'MMMM d, yyyy HH:00');
+      case 'minute':
+        return format(date, timeFormat === '12h' ? 'MMMM d, yyyy hh:mm a' : 'MMMM d, yyyy HH:mm');
+      default:
+        return format(date, 'MMMM d, yyyy');
+    }
+  };
   return (
     <motion.div
       initial={{ opacity: 0, x: isLeft ? -50 : 50, y: 20 }}
@@ -36,18 +38,18 @@ export default function TimelineEntry({ entry, position, isLeft }) {
       className={`absolute ${isLeft ? 'right-1/2 pr-8' : 'left-1/2 pl-8'} w-1/2`}
       style={{ top: `${position * 180 + 60}px` }}
     >
-      <Card className="bg-white/90 backdrop-blur-sm border-slate-200/60 hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1">
+      <Card className="bg-white/90 backdrop-blur-sm border-slate-200/60 hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 dark:bg-slate-800/90 dark:border-slate-700/60">
         <CardContent className="p-6">
           <div className="flex items-start gap-4">
             <div className="w-12 h-12 rounded-xl bg-gradient-to-r from-blue-500 to-indigo-500 flex items-center justify-center shadow-lg flex-shrink-0">
               <Calendar className="w-6 h-6 text-white" />
             </div>
             <div className="flex-1 min-w-0">
-              <h3 className="font-bold text-slate-900 text-lg leading-tight mb-1">{entry.title}</h3>
-              <p className="text-slate-600 text-sm leading-relaxed mb-3">
+              <h3 className="font-bold text-slate-900 text-lg leading-tight mb-1 dark:text-slate-100">{entry.title}</h3>
+              <p className="text-slate-600 text-sm leading-relaxed mb-3 dark:text-slate-300">
                 {entry.description}
               </p>
-              <div className="flex items-center gap-2 text-xs font-medium text-slate-500">
+              <div className="flex items-center gap-2 text-xs font-medium text-slate-500 dark:text-slate-400">
                 <Calendar className="w-3 h-3" />
                 {formatEntryDate(entry.date, entry.precision)}
               </div>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Chronos</title>
     <!-- Include Tailwind CSS for styling -->
+    <script>
+      tailwind.config = {
+        darkMode: 'class'
+      }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>

--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -44,23 +44,23 @@ export default function Admin() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-amber-50">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-amber-50 dark:from-slate-900 dark:via-slate-900 dark:to-slate-800">
       <div className="max-w-4xl mx-auto px-6 py-12">
-        <motion.div 
+        <motion.div
           initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
           className="text-center mb-12"
         >
-          <div className="inline-flex items-center gap-3 bg-white/80 backdrop-blur-sm rounded-2xl px-6 py-3 shadow-lg border border-slate-200/60 mb-6">
-            <Settings className="w-6 h-6 text-slate-700" />
-            <span className="text-slate-600 font-medium">Admin Panel</span>
+          <div className="inline-flex items-center gap-3 bg-white/80 backdrop-blur-sm rounded-2xl px-6 py-3 shadow-lg border border-slate-200/60 mb-6 dark:bg-slate-800/80 dark:border-slate-700/60">
+            <Settings className="w-6 h-6 text-slate-700 dark:text-slate-300" />
+            <span className="text-slate-600 font-medium dark:text-slate-300">Admin Panel</span>
           </div>
           
-          <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-slate-900 via-slate-800 to-amber-800 bg-clip-text text-transparent mb-4">
+          <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-slate-900 via-slate-800 to-amber-800 bg-clip-text text-transparent mb-4 dark:from-slate-100 dark:via-slate-100 dark:to-amber-400">
             Schedule Control
           </h1>
-          <p className="text-lg text-slate-600 max-w-2xl mx-auto leading-relaxed">
+          <p className="text-lg text-slate-600 max-w-2xl mx-auto leading-relaxed dark:text-slate-300">
             Add new items to your daily schedule. Each item will automatically position itself based on date.
           </p>
         </motion.div>
@@ -90,16 +90,16 @@ export default function Admin() {
           </div>
           
           <div className="space-y-6">
-            <Card className="bg-white/90 backdrop-blur-sm border-slate-200/60 shadow-lg">
+            <Card className="bg-white/90 backdrop-blur-sm border-slate-200/60 shadow-lg dark:bg-slate-800/90 dark:border-slate-700/60">
               <CardHeader className="pb-4">
-                <CardTitle className="flex items-center gap-3 text-lg font-bold text-slate-900">
+                <CardTitle className="flex items-center gap-3 text-lg font-bold text-slate-900 dark:text-slate-100">
                   <Clock className="w-5 h-5 text-amber-500" />
                   Recent Entries
                 </CardTitle>
               </CardHeader>
               <CardContent>
                 {recentEntries.length === 0 ? (
-                  <p className="text-slate-500 text-center py-8">No entries yet</p>
+                  <p className="text-slate-500 text-center py-8 dark:text-slate-300">No entries yet</p>
                 ) : (
                   <div className="space-y-3">
                     {recentEntries.map((entry) => (
@@ -107,12 +107,12 @@ export default function Admin() {
                         key={entry.id}
                         initial={{ opacity: 0, x: 20 }}
                         animate={{ opacity: 1, x: 0 }}
-                        className="p-3 bg-slate-50 rounded-xl border border-slate-100"
+                        className="p-3 bg-slate-50 rounded-xl border border-slate-100 dark:bg-slate-700 dark:border-slate-600"
                       >
-                        <h4 className="font-semibold text-slate-900 text-sm mb-1">
+                        <h4 className="font-semibold text-slate-900 text-sm mb-1 dark:text-slate-100">
                           {entry.title}
                         </h4>
-                        <p className="text-xs text-slate-500">
+                        <p className="text-xs text-slate-500 dark:text-slate-300">
                           {new Date(entry.date).toLocaleDateString()}
                         </p>
                       </motion.div>
@@ -122,12 +122,12 @@ export default function Admin() {
               </CardContent>
             </Card>
 
-            <Card className="bg-gradient-to-br from-amber-50 to-orange-50 border-amber-200/60 shadow-lg">
+            <Card className="bg-gradient-to-br from-amber-50 to-orange-50 border-amber-200/60 shadow-lg dark:from-amber-900 dark:to-amber-800">
               <CardContent className="p-6">
                 <div className="text-center">
                   <Sparkles className="w-8 h-8 text-amber-600 mx-auto mb-3" />
-                  <h3 className="font-bold text-amber-900 mb-2">Intelligent Positioning</h3>
-                  <p className="text-sm text-amber-700 leading-relaxed">
+                  <h3 className="font-bold text-amber-900 mb-2 dark:text-amber-200">Intelligent Positioning</h3>
+                  <p className="text-sm text-amber-700 leading-relaxed dark:text-amber-300">
                     Your schedule automatically sorts and positions entries by date, creating an easy-to-follow plan.
                   </p>
                 </div>

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -79,17 +79,17 @@ export default function Schedule() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-amber-50 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-amber-50 dark:from-slate-900 dark:via-slate-900 dark:to-slate-800 flex items-center justify-center">
         <div className="text-center">
           <div className="w-16 h-16 border-4 border-slate-300 border-t-amber-500 rounded-full animate-spin mx-auto mb-4"></div>
-          <p className="text-slate-600 font-medium">Loading your schedule...</p>
+          <p className="text-slate-600 font-medium dark:text-slate-300">Loading your schedule...</p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-amber-50">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-amber-50 dark:from-slate-900 dark:via-slate-900 dark:to-slate-800">
       <div className="max-w-7xl mx-auto px-6 py-12">
         <motion.div
           initial={{ opacity: 0, y: -20 }}
@@ -97,15 +97,15 @@ export default function Schedule() {
           transition={{ duration: 0.6 }}
           className="text-center mb-16"
         >
-          <div className="inline-flex items-center gap-3 bg-white/80 backdrop-blur-sm rounded-2xl px-6 py-3 shadow-lg border border-slate-200/60 mb-6">
+          <div className="inline-flex items-center gap-3 bg-white/80 backdrop-blur-sm rounded-2xl px-6 py-3 shadow-lg border border-slate-200/60 mb-6 dark:bg-slate-800/80 dark:border-slate-700/60">
             <Calendar className="w-6 h-6 text-amber-500" />
-            <span className="text-slate-600 font-medium">Daily Schedule</span>
+            <span className="text-slate-600 font-medium dark:text-slate-300">Daily Schedule</span>
           </div>
           
-            <h1 className="text-5xl md:text-6xl font-bold bg-gradient-to-r from-slate-900 via-slate-800 to-amber-800 bg-clip-text text-transparent mb-4">
+            <h1 className="text-5xl md:text-6xl font-bold bg-gradient-to-r from-slate-900 via-slate-800 to-amber-800 bg-clip-text text-transparent mb-4 dark:from-slate-100 dark:via-slate-100 dark:to-amber-400">
               Your Day Plan
             </h1>
-            <p className="text-xl text-slate-600 max-w-2xl mx-auto leading-relaxed">
+            <p className="text-xl text-slate-600 max-w-2xl mx-auto leading-relaxed dark:text-slate-300">
               Plan your week and view each day with an intuitive schedule and clear visualizations
             </p>
 
@@ -115,7 +115,7 @@ export default function Schedule() {
 
           {entries.length > 0 && (
             <div className="flex items-center justify-center gap-6 mt-8">
-              <div className="flex items-center gap-2 text-slate-600">
+            <div className="flex items-center gap-2 text-slate-600 dark:text-slate-300">
                 <TrendingUp className="w-5 h-5 text-emerald-500" />
                   <span className="font-medium">{entries.length} Schedule Entries</span>
               </div>
@@ -127,7 +127,7 @@ export default function Schedule() {
               placeholder="Search activities..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="border-slate-300 flex-1"
+              className="border-slate-300 flex-1 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
             />
             <Button
               onClick={handleSearch}
@@ -139,17 +139,17 @@ export default function Schedule() {
         </motion.div>
 
         {entries.length === 0 ? (
-          <motion.div 
+          <motion.div
             initial={{ opacity: 0, scale: 0.95 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 0.5 }}
             className="text-center py-24"
           >
-            <div className="w-24 h-24 bg-gradient-to-br from-slate-200 to-slate-300 rounded-full flex items-center justify-center mx-auto mb-8">
-              <Calendar className="w-12 h-12 text-slate-500" />
+            <div className="w-24 h-24 bg-gradient-to-br from-slate-200 to-slate-300 rounded-full flex items-center justify-center mx-auto mb-8 dark:from-slate-700 dark:to-slate-600">
+              <Calendar className="w-12 h-12 text-slate-500 dark:text-slate-300" />
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 mb-4">Your Schedule Awaits</h2>
-            <p className="text-slate-600 text-lg max-w-md mx-auto mb-8">
+            <h2 className="text-2xl font-bold text-slate-900 mb-4 dark:text-slate-100">Your Schedule Awaits</h2>
+            <p className="text-slate-600 text-lg max-w-md mx-auto mb-8 dark:text-slate-300">
               Use the selector above to create a timetable, then add your first entry in the Admin Panel.
             </p>
           </motion.div>

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Select, SelectItem } from '@/components/ui/select';
+import { useSettings } from '@/src/SettingsContext';
+
+export default function Settings() {
+  const { darkMode, setDarkMode, timeFormat, setTimeFormat } = useSettings();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-amber-50 dark:from-slate-900 dark:via-slate-900 dark:to-slate-800 p-8">
+      <Card className="max-w-xl mx-auto bg-white/90 backdrop-blur-sm border-slate-200/60 shadow-lg dark:bg-slate-800/90 dark:border-slate-700">
+        <CardHeader>
+          <CardTitle className="text-slate-900 dark:text-slate-100">Settings</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="dark-mode" className="text-slate-700 dark:text-slate-200">Dark mode</Label>
+            <input
+              id="dark-mode"
+              type="checkbox"
+              checked={darkMode}
+              onChange={e => setDarkMode(e.target.checked)}
+              className="w-4 h-4"
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="time-format" className="text-slate-700 dark:text-slate-200">Time format</Label>
+            <Select
+              value={timeFormat}
+              onValueChange={v => setTimeFormat(v as '24h' | '12h')}
+            >
+              <SelectItem value="24h">24-hour</SelectItem>
+              <SelectItem value="12h">12-hour</SelectItem>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/SettingsContext.tsx
+++ b/src/SettingsContext.tsx
@@ -1,0 +1,58 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type TimeFormat = '24h' | '12h';
+interface SettingsContextValue {
+  darkMode: boolean;
+  setDarkMode: (value: boolean) => void;
+  timeFormat: TimeFormat;
+  setTimeFormat: (format: TimeFormat) => void;
+}
+
+const SettingsContext = createContext<SettingsContextValue | undefined>(undefined);
+
+export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [darkMode, setDarkModeState] = useState<boolean>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('darkMode');
+      return stored ? stored === 'true' : false;
+    }
+    return false;
+  });
+
+  const [timeFormat, setTimeFormatState] = useState<TimeFormat>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('timeFormat');
+      return stored === '12h' ? '12h' : '24h';
+    }
+    return '24h';
+  });
+
+  useEffect(() => {
+    localStorage.setItem('darkMode', String(darkMode));
+    if (darkMode) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [darkMode]);
+
+  useEffect(() => {
+    localStorage.setItem('timeFormat', timeFormat);
+  }, [timeFormat]);
+
+  const setDarkMode = (value: boolean) => setDarkModeState(value);
+  const setTimeFormat = (format: TimeFormat) => setTimeFormatState(format);
+
+  return (
+    <SettingsContext.Provider value={{ darkMode, setDarkMode, timeFormat, setTimeFormat }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = () => {
+  const ctx = useContext(SettingsContext);
+  if (!ctx) throw new Error('useSettings must be used within SettingsProvider');
+  return ctx;
+};
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,16 +4,21 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Layout from '../Layout';
 import Admin from '../pages/admin';
 import Schedule from '../pages/schedule';
+import Settings from '../pages/settings';
+import { SettingsProvider } from './SettingsContext';
 
 function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/admin" element={<Layout currentPageName="Admin"><Admin /></Layout>} />
-        <Route path="/schedule" element={<Layout currentPageName="Schedule"><Schedule /></Layout>} />
-        <Route path="/" element={<Layout currentPageName="Schedule"><Schedule /></Layout>} />
-      </Routes>
-    </BrowserRouter>
+    <SettingsProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/admin" element={<Layout currentPageName="Admin"><Admin /></Layout>} />
+          <Route path="/schedule" element={<Layout currentPageName="Schedule"><Schedule /></Layout>} />
+          <Route path="/settings" element={<Layout currentPageName="Settings"><Settings /></Layout>} />
+          <Route path="/" element={<Layout currentPageName="Schedule"><Schedule /></Layout>} />
+        </Routes>
+      </BrowserRouter>
+    </SettingsProvider>
   );
 }
 


### PR DESCRIPTION
## Summary
- add context to persist dark mode and 12/24-hour time preference
- create stylized settings page to toggle theme and time format
- update layout and timeline entries to honor dark theme and chosen time format

## Testing
- `npm test` *(fails: Missing script "test")*
- `node node_modules/vite/bin/vite.js build`

------
https://chatgpt.com/codex/tasks/task_e_688ec31b6d5c832084feaae963655456