### PR TITLE
fix: load Tailwind CDN before configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,12 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Chronos</title>
     <!-- Include Tailwind CSS for styling -->
+    <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {
         darkMode: 'class'
       }
     </script>
-    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- load Tailwind CDN script before configuring dark mode to avoid runtime reference error

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ec709455083209d127d1a497d82cb