### PR TITLE
Add language preference toggle

### DIFF
--- a/Layout.tsx
+++ b/Layout.tsx
@@ -16,27 +16,16 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "@/components/ui/sidebar";
-
-const navigationItems = [
-  {
-    title: "Schedule",
-    url: createPageUrl("Schedule"),
-    icon: History,
-  },
-  {
-    title: "Admin Panel",
-    url: createPageUrl("Admin"),
-    icon: Settings,
-  },
-  {
-    title: "Settings",
-    url: createPageUrl("Settings"),
-    icon: Cog,
-  },
-];
+import { useTranslation } from "@/src/i18n";
 
 export default function Layout({ children, currentPageName }) {
   const location = useLocation();
+  const { t } = useTranslation();
+  const navigationItems = [
+    { title: t('nav.schedule'), url: createPageUrl('Schedule'), icon: History },
+    { title: t('nav.admin'), url: createPageUrl('Admin'), icon: Settings },
+    { title: t('nav.settings'), url: createPageUrl('Settings'), icon: Cog },
+  ];
 
   return (
     <SidebarProvider>
@@ -59,7 +48,7 @@ export default function Layout({ children, currentPageName }) {
               </div>
               <div>
                 <h2 className="font-bold text-slate-900 text-lg dark:text-slate-100">Chronos</h2>
-                <p className="text-xs text-slate-500 font-medium dark:text-slate-400">Daily Schedule</p>
+                <p className="text-xs text-slate-500 font-medium dark:text-slate-400">{t('schedule.tag')}</p>
               </div>
             </div>
           </SidebarHeader>
@@ -67,7 +56,7 @@ export default function Layout({ children, currentPageName }) {
           <SidebarContent className="p-3">
             <SidebarGroup>
               <SidebarGroupLabel className="text-xs font-semibold text-slate-600 uppercase tracking-wider px-3 py-3 dark:text-slate-300">
-                Navigation
+                {t('nav.navigation')}
               </SidebarGroupLabel>
               <SidebarGroupContent>
                 <SidebarMenu className="space-y-1">

--- a/components/admin/CalendarEditor.tsx
+++ b/components/admin/CalendarEditor.tsx
@@ -2,11 +2,13 @@ import React, { useEffect, useState, useMemo } from 'react';
 import { Calendar, dateFnsLocalizer } from 'react-big-calendar';
 import { format, parse, startOfWeek, getDay } from 'date-fns';
 import enUS from 'date-fns/locale/en-US';
+import fr from 'date-fns/locale/fr';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import { TimelineEntry } from '@/entities/TimelineEntry';
 import { useSettings } from '@/src/SettingsContext';
+import { useTranslation } from '@/src/i18n';
 
-const locales = { 'en-US': enUS };
+const locales = { 'en-US': enUS, fr };
 const localizer = dateFnsLocalizer({ format, parse, startOfWeek, getDay, locales });
 
 interface Props {
@@ -16,6 +18,7 @@ interface Props {
 export default function CalendarEditor({ timetableId }: Props) {
   const [events, setEvents] = useState<any[]>([]);
   const { timeFormat } = useSettings();
+  const { t, language } = useTranslation();
 
   const formats = useMemo(() => {
     const fmt = timeFormat === '12h' ? 'hh:mm a' : 'HH:mm';
@@ -43,14 +46,14 @@ export default function CalendarEditor({ timetableId }: Props) {
 
   const handleSelectSlot = async ({ start }: { start: Date }) => {
     if (!timetableId) return;
-    const title = window.prompt('Event title');
+    const title = window.prompt(t('calendarEditor.eventPrompt'));
     if (!title) return;
     await TimelineEntry.create({ title, description: '', date: start.toISOString(), precision: 'minute', timetableId });
     await load();
   };
 
   const handleSelectEvent = async (event: any) => {
-    if (window.confirm('Delete this event?')) {
+    if (window.confirm(t('calendarEditor.deleteConfirm'))) {
       await TimelineEntry.delete(event.id);
       await load();
     }
@@ -69,6 +72,7 @@ export default function CalendarEditor({ timetableId }: Props) {
         onSelectSlot={handleSelectSlot}
         onSelectEvent={handleSelectEvent}
         formats={formats}
+        culture={language === 'fr' ? 'fr' : 'en-US'}
       />
     </div>
   );

--- a/components/admin/EntryForm.tsx
+++ b/components/admin/EntryForm.tsx
@@ -7,6 +7,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Plus, Sparkles } from "lucide-react";
 import { motion } from "framer-motion";
+import { useTranslation } from "@/src/i18n";
 
 export default function EntryForm({ onSubmit, isLoading }) {
   const [formData, setFormData] = useState({
@@ -15,6 +16,7 @@ export default function EntryForm({ onSubmit, isLoading }) {
     date: "",
     precision: "day",
   });
+  const { t } = useTranslation();
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -50,7 +52,7 @@ export default function EntryForm({ onSubmit, isLoading }) {
             <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-amber-500 to-orange-500 flex items-center justify-center">
               <Sparkles className="w-5 h-5 text-white" />
             </div>
-            Add Schedule Item
+            {t('entryForm.title')}
           </CardTitle>
         </CardHeader>
 
@@ -59,13 +61,13 @@ export default function EntryForm({ onSubmit, isLoading }) {
             <div className="grid md:grid-cols-2 gap-6">
               <div className="space-y-2">
                 <Label htmlFor="title" className="text-sm font-semibold text-slate-700">
-                  Title
+                  {t('entryForm.fields.title')}
                 </Label>
                 <Input
                   id="title"
                   value={formData.title}
                   onChange={(e) => handleChange("title", e.target.value)}
-                  placeholder="Enter event title..."
+                  placeholder={t('entryForm.fields.titlePlaceholder')}
                   required
                   className="border-slate-200 focus:border-amber-400 focus:ring-amber-400/20"
                 />
@@ -73,7 +75,7 @@ export default function EntryForm({ onSubmit, isLoading }) {
 
               <div className="space-y-2">
                 <Label htmlFor="date" className="text-sm font-semibold text-slate-700">
-                  Date
+                  {t('entryForm.fields.date')}
                 </Label>
                 <Input
                   id="date"
@@ -88,30 +90,30 @@ export default function EntryForm({ onSubmit, isLoading }) {
             </div>
 
             <div className="space-y-2">
-              <Label className="text-sm font-semibold text-slate-700">Precision</Label>
+              <Label className="text-sm font-semibold text-slate-700">{t('entryForm.fields.precision')}</Label>
               <Select value={formData.precision} onValueChange={(value) => handleChange("precision", value)}>
                 <SelectTrigger className="border-slate-200 focus:border-amber-400 focus:ring-amber-400/20">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="year">Year</SelectItem>
-                  <SelectItem value="month">Month</SelectItem>
-                  <SelectItem value="day">Day</SelectItem>
-                  <SelectItem value="hour">Hour</SelectItem>
-                  <SelectItem value="minute">Minute</SelectItem>
+                  <SelectItem value="year">{t('entryForm.precision.year')}</SelectItem>
+                  <SelectItem value="month">{t('entryForm.precision.month')}</SelectItem>
+                  <SelectItem value="day">{t('entryForm.precision.day')}</SelectItem>
+                  <SelectItem value="hour">{t('entryForm.precision.hour')}</SelectItem>
+                  <SelectItem value="minute">{t('entryForm.precision.minute')}</SelectItem>
                 </SelectContent>
               </Select>
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="description" className="text-sm font-semibold text-slate-700">
-                Description
+                {t('entryForm.fields.description')}
               </Label>
               <Textarea
                 id="description"
                 value={formData.description}
                 onChange={(e) => handleChange("description", e.target.value)}
-                placeholder="Describe this scheduled activity..."
+                placeholder={t('entryForm.fields.descriptionPlaceholder')}
                 rows={3}
                 className="border-slate-200 focus:border-amber-400 focus:ring-amber-400/20 resize-none"
               />
@@ -125,12 +127,12 @@ export default function EntryForm({ onSubmit, isLoading }) {
               {isLoading ? (
                 <div className="flex items-center gap-2">
                   <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                  Adding to Schedule...
+                  {t('entryForm.submitting')}
                 </div>
               ) : (
                 <>
                   <Plus className="w-5 h-5 mr-2" />
-                  Add to Schedule
+                  {t('entryForm.submit')}
                 </>
               )}
             </Button>

--- a/components/admin/ImportEntries.tsx
+++ b/components/admin/ImportEntries.tsx
@@ -5,10 +5,12 @@ import { Input } from "@/components/ui/input";
 import { Upload } from "lucide-react";
 import { TimelineEntry } from "@/entities/TimelineEntry";
 import { Timetable } from "@/entities/Timetable";
+import { useTranslation } from "@/src/i18n";
 
 export default function ImportEntries({ onImported }) {
   const [file, setFile] = useState<File | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const { t } = useTranslation();
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const f = e.target.files && e.target.files[0];
@@ -44,7 +46,7 @@ export default function ImportEntries({ onImported }) {
           <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-green-500 to-emerald-500 flex items-center justify-center">
             <Upload className="w-5 h-5 text-white" />
           </div>
-          Import JSON
+          {t('importEntries.title')}
         </CardTitle>
       </CardHeader>
       <CardContent>
@@ -55,7 +57,7 @@ export default function ImportEntries({ onImported }) {
             onClick={handleImport}
             className="w-full bg-gradient-to-r from-slate-800 to-slate-900 hover:from-slate-900 hover:to-black text-white shadow-lg hover:shadow-xl transition-all duration-300 py-3"
           >
-            {isLoading ? "Importing..." : "Import"}
+            {isLoading ? t('importEntries.importing') : t('importEntries.import')}
           </Button>
         </div>
       </CardContent>

--- a/components/admin/TimetableManager.tsx
+++ b/components/admin/TimetableManager.tsx
@@ -3,6 +3,7 @@ import { Timetable, TimetableType } from '@/entities/Timetable';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { useTranslation } from '@/src/i18n';
 
 interface Props {
   value: number | null;
@@ -13,6 +14,7 @@ export default function TimetableManager({ value, onChange }: Props) {
   const [timetables, setTimetables] = useState<TimetableType[]>([]);
   const [newName, setNewName] = useState('');
   const [confirmDelete, setConfirmDelete] = useState<{ id?: number; countdown: number } | null>(null);
+  const { t } = useTranslation();
 
   useEffect(() => {
     load();
@@ -61,7 +63,7 @@ export default function TimetableManager({ value, onChange }: Props) {
     <div className="space-y-2">
       <Select value={value ? String(value) : undefined} onValueChange={(v) => onChange(Number(v))}>
         <SelectTrigger className="border-slate-200">
-          <SelectValue placeholder="Select timetable" />
+          <SelectValue placeholder={t('timetableManager.selectPlaceholder')} />
         </SelectTrigger>
         <SelectContent>
           {timetables.map((t) => (
@@ -72,18 +74,18 @@ export default function TimetableManager({ value, onChange }: Props) {
         </SelectContent>
       </Select>
       <div className="flex gap-2">
-        <Input value={newName} onChange={(e) => setNewName(e.target.value)} placeholder="New timetable" className="border-slate-200 flex-1" />
-        <Button onClick={handleCreate} className="bg-amber-500 text-white border-amber-600">Create</Button>
+        <Input value={newName} onChange={(e) => setNewName(e.target.value)} placeholder={t('timetableManager.newPlaceholder')} className="border-slate-200 flex-1" />
+        <Button onClick={handleCreate} className="bg-amber-500 text-white border-amber-600">{t('timetableManager.create')}</Button>
       </div>
       <div className="flex gap-2">
-        <Button onClick={() => initiateDelete(value ?? undefined)} disabled={!value} className="flex-1 bg-red-500 text-white border-red-600 disabled:opacity-50">Delete</Button>
-        <Button onClick={() => initiateDelete()} className="flex-1 bg-red-500 text-white border-red-600">Delete All</Button>
+        <Button onClick={() => initiateDelete(value ?? undefined)} disabled={!value} className="flex-1 bg-red-500 text-white border-red-600 disabled:opacity-50">{t('timetableManager.delete')}</Button>
+        <Button onClick={() => initiateDelete()} className="flex-1 bg-red-500 text-white border-red-600">{t('timetableManager.deleteAll')}</Button>
       </div>
       {confirmDelete && (
         <div className="flex items-center gap-2 text-sm text-red-700">
-          <span>Deleting in {confirmDelete.countdown}...</span>
-          <Button onClick={async () => { await handleDelete(confirmDelete.id); setConfirmDelete(null); }} className="bg-red-500 text-white border-red-600">Confirm now</Button>
-          <Button onClick={() => setConfirmDelete(null)} className="border-slate-200">Cancel</Button>
+          <span>{t('timetableManager.deletingIn')} {confirmDelete.countdown}...</span>
+          <Button onClick={async () => { await handleDelete(confirmDelete.id); setConfirmDelete(null); }} className="bg-red-500 text-white border-red-600">{t('timetableManager.confirmNow')}</Button>
+          <Button onClick={() => setConfirmDelete(null)} className="border-slate-200">{t('timetableManager.cancel')}</Button>
         </div>
       )}
     </div>

--- a/components/timeline/TimelineEntry.tsx
+++ b/components/timeline/TimelineEntry.tsx
@@ -4,25 +4,27 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Calendar } from "lucide-react";
 import { format, parseISO } from "date-fns";
 import { useSettings } from "@/src/SettingsContext";
+import { useTranslation } from "@/src/i18n";
 
 export default function TimelineEntry({ entry, position, isLeft }) {
   const { timeFormat } = useSettings();
+  const { locale } = useTranslation();
 
   const formatEntryDate = (dateStr: string, precision: string) => {
     const date = parseISO(dateStr);
     switch (precision) {
       case 'year':
-        return format(date, 'yyyy');
+        return format(date, 'yyyy', { locale });
       case 'month':
-        return format(date, 'MMMM yyyy');
+        return format(date, 'MMMM yyyy', { locale });
       case 'day':
-        return format(date, 'MMMM d, yyyy');
+        return format(date, 'MMMM d, yyyy', { locale });
       case 'hour':
-        return format(date, timeFormat === '12h' ? 'MMMM d, yyyy hh:00 a' : 'MMMM d, yyyy HH:00');
+        return format(date, timeFormat === '12h' ? 'MMMM d, yyyy hh:00 a' : 'MMMM d, yyyy HH:00', { locale });
       case 'minute':
-        return format(date, timeFormat === '12h' ? 'MMMM d, yyyy hh:mm a' : 'MMMM d, yyyy HH:mm');
+        return format(date, timeFormat === '12h' ? 'MMMM d, yyyy hh:mm a' : 'MMMM d, yyyy HH:mm', { locale });
       default:
-        return format(date, 'MMMM d, yyyy');
+        return format(date, 'MMMM d, yyyy', { locale });
     }
   };
   return (

--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -7,12 +7,14 @@ import TimetableManager from "../components/admin/TimetableManager";
 import CalendarEditor from "../components/admin/CalendarEditor";
 import { Settings, Sparkles, Clock, CheckCircle } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useTranslation } from "@/src/i18n";
 
 export default function Admin() {
   const [isLoading, setIsLoading] = useState(false);
   const [recentEntries, setRecentEntries] = useState([]);
   const [showSuccess, setShowSuccess] = useState(false);
   const [timetableId, setTimetableId] = useState<number | null>(null);
+  const { t, language } = useTranslation();
 
   useEffect(() => {
     if (timetableId) loadRecentEntries();
@@ -54,14 +56,14 @@ export default function Admin() {
         >
           <div className="inline-flex items-center gap-3 bg-white/80 backdrop-blur-sm rounded-2xl px-6 py-3 shadow-lg border border-slate-200/60 mb-6 dark:bg-slate-800/80 dark:border-slate-700/60">
             <Settings className="w-6 h-6 text-slate-700 dark:text-slate-300" />
-            <span className="text-slate-600 font-medium dark:text-slate-300">Admin Panel</span>
+            <span className="text-slate-600 font-medium dark:text-slate-300">{t('admin.tag')}</span>
           </div>
           
           <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-slate-900 via-slate-800 to-amber-800 bg-clip-text text-transparent mb-4 dark:from-slate-100 dark:via-slate-100 dark:to-amber-400">
-            Schedule Control
+            {t('admin.title')}
           </h1>
           <p className="text-lg text-slate-600 max-w-2xl mx-auto leading-relaxed dark:text-slate-300">
-            Add new items to your daily schedule. Each item will automatically position itself based on date.
+            {t('admin.description')}
           </p>
         </motion.div>
 
@@ -75,7 +77,7 @@ export default function Admin() {
             <div className="bg-gradient-to-r from-emerald-50 to-teal-50 border border-emerald-200 rounded-2xl p-4">
               <div className="flex items-center gap-3 text-emerald-800">
                 <CheckCircle className="w-6 h-6" />
-                <span className="font-semibold">Schedule item added successfully!</span>
+                <span className="font-semibold">{t('admin.success')}</span>
               </div>
             </div>
           </motion.div>
@@ -94,12 +96,12 @@ export default function Admin() {
               <CardHeader className="pb-4">
                 <CardTitle className="flex items-center gap-3 text-lg font-bold text-slate-900 dark:text-slate-100">
                   <Clock className="w-5 h-5 text-amber-500" />
-                  Recent Entries
+                  {t('admin.recentEntries')}
                 </CardTitle>
               </CardHeader>
               <CardContent>
                 {recentEntries.length === 0 ? (
-                  <p className="text-slate-500 text-center py-8 dark:text-slate-300">No entries yet</p>
+                  <p className="text-slate-500 text-center py-8 dark:text-slate-300">{t('admin.noEntries')}</p>
                 ) : (
                   <div className="space-y-3">
                     {recentEntries.map((entry) => (
@@ -113,7 +115,7 @@ export default function Admin() {
                           {entry.title}
                         </h4>
                         <p className="text-xs text-slate-500 dark:text-slate-300">
-                          {new Date(entry.date).toLocaleDateString()}
+                          {new Date(entry.date).toLocaleDateString(language === 'fr' ? 'fr-FR' : 'en-US')}
                         </p>
                       </motion.div>
                     ))}
@@ -126,9 +128,9 @@ export default function Admin() {
               <CardContent className="p-6">
                 <div className="text-center">
                   <Sparkles className="w-8 h-8 text-amber-600 mx-auto mb-3" />
-                  <h3 className="font-bold text-amber-900 mb-2 dark:text-amber-200">Intelligent Positioning</h3>
+                  <h3 className="font-bold text-amber-900 mb-2 dark:text-amber-200">{t('admin.featureTitle')}</h3>
                   <p className="text-sm text-amber-700 leading-relaxed dark:text-amber-300">
-                    Your schedule automatically sorts and positions entries by date, creating an easy-to-follow plan.
+                    {t('admin.featureDesc')}
                   </p>
                 </div>
               </CardContent>

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -7,6 +7,7 @@ import TimelineEntryComponent from "../components/timeline/TimelineEntry";
 import TimelineLine from "../components/timeline/TimelineLine";
 import { Calendar, TrendingUp } from "lucide-react";
 import TimetableManager from "../components/admin/TimetableManager";
+import { useTranslation } from "@/src/i18n";
 
 export default function Schedule() {
   const [entries, setEntries] = useState([]);
@@ -16,6 +17,7 @@ export default function Schedule() {
   const [scrollTop, setScrollTop] = useState(0);
   const [containerHeight, setContainerHeight] = useState(0);
   const [timetableId, setTimetableId] = useState<number | null>(null);
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (timetableId) {
@@ -82,7 +84,7 @@ export default function Schedule() {
       <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-amber-50 dark:from-slate-900 dark:via-slate-900 dark:to-slate-800 flex items-center justify-center">
         <div className="text-center">
           <div className="w-16 h-16 border-4 border-slate-300 border-t-amber-500 rounded-full animate-spin mx-auto mb-4"></div>
-          <p className="text-slate-600 font-medium dark:text-slate-300">Loading your schedule...</p>
+          <p className="text-slate-600 font-medium dark:text-slate-300">{t('schedule.loading')}</p>
         </div>
       </div>
     );
@@ -99,14 +101,14 @@ export default function Schedule() {
         >
           <div className="inline-flex items-center gap-3 bg-white/80 backdrop-blur-sm rounded-2xl px-6 py-3 shadow-lg border border-slate-200/60 mb-6 dark:bg-slate-800/80 dark:border-slate-700/60">
             <Calendar className="w-6 h-6 text-amber-500" />
-            <span className="text-slate-600 font-medium dark:text-slate-300">Daily Schedule</span>
+            <span className="text-slate-600 font-medium dark:text-slate-300">{t('schedule.tag')}</span>
           </div>
           
             <h1 className="text-5xl md:text-6xl font-bold bg-gradient-to-r from-slate-900 via-slate-800 to-amber-800 bg-clip-text text-transparent mb-4 dark:from-slate-100 dark:via-slate-100 dark:to-amber-400">
-              Your Day Plan
+              {t('schedule.title')}
             </h1>
             <p className="text-xl text-slate-600 max-w-2xl mx-auto leading-relaxed dark:text-slate-300">
-              Plan your week and view each day with an intuitive schedule and clear visualizations
+              {t('schedule.description')}
             </p>
 
           <div className="max-w-md mx-auto mt-8">
@@ -117,14 +119,14 @@ export default function Schedule() {
             <div className="flex items-center justify-center gap-6 mt-8">
             <div className="flex items-center gap-2 text-slate-600 dark:text-slate-300">
                 <TrendingUp className="w-5 h-5 text-emerald-500" />
-                  <span className="font-medium">{entries.length} Schedule Entries</span>
+                  <span className="font-medium">{entries.length} {t('schedule.entriesCountLabel')}</span>
               </div>
             </div>
           )}
 
           <div className="max-w-md mx-auto mt-8 flex gap-2">
             <Input
-              placeholder="Search activities..."
+              placeholder={t('schedule.searchPlaceholder')}
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               className="border-slate-300 flex-1 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
@@ -133,7 +135,7 @@ export default function Schedule() {
               onClick={handleSearch}
               className="bg-amber-500 hover:bg-amber-600 text-white border-amber-600"
             >
-              Search
+              {t('schedule.searchButton')}
             </Button>
           </div>
         </motion.div>
@@ -148,9 +150,9 @@ export default function Schedule() {
             <div className="w-24 h-24 bg-gradient-to-br from-slate-200 to-slate-300 rounded-full flex items-center justify-center mx-auto mb-8 dark:from-slate-700 dark:to-slate-600">
               <Calendar className="w-12 h-12 text-slate-500 dark:text-slate-300" />
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 mb-4 dark:text-slate-100">Your Schedule Awaits</h2>
+            <h2 className="text-2xl font-bold text-slate-900 mb-4 dark:text-slate-100">{t('schedule.emptyTitle')}</h2>
             <p className="text-slate-600 text-lg max-w-md mx-auto mb-8 dark:text-slate-300">
-              Use the selector above to create a timetable, then add your first entry in the Admin Panel.
+              {t('schedule.emptyDescription')}
             </p>
           </motion.div>
         ) : (

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -3,19 +3,21 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Select, SelectItem } from '@/components/ui/select';
 import { useSettings } from '@/src/SettingsContext';
+import { useTranslation } from '@/src/i18n';
 
 export default function Settings() {
-  const { darkMode, setDarkMode, timeFormat, setTimeFormat } = useSettings();
+  const { darkMode, setDarkMode, timeFormat, setTimeFormat, language, setLanguage } = useSettings();
+  const { t } = useTranslation();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-amber-50 dark:from-slate-900 dark:via-slate-900 dark:to-slate-800 p-8">
       <Card className="max-w-xl mx-auto bg-white/90 backdrop-blur-sm border-slate-200/60 shadow-lg dark:bg-slate-800/90 dark:border-slate-700">
         <CardHeader>
-          <CardTitle className="text-slate-900 dark:text-slate-100">Settings</CardTitle>
+          <CardTitle className="text-slate-900 dark:text-slate-100">{t('settings.title')}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-6">
           <div className="flex items-center justify-between">
-            <Label htmlFor="dark-mode" className="text-slate-700 dark:text-slate-200">Dark mode</Label>
+            <Label htmlFor="dark-mode" className="text-slate-700 dark:text-slate-200">{t('settings.darkMode')}</Label>
             <input
               id="dark-mode"
               type="checkbox"
@@ -25,13 +27,23 @@ export default function Settings() {
             />
           </div>
           <div className="flex items-center justify-between">
-            <Label htmlFor="time-format" className="text-slate-700 dark:text-slate-200">Time format</Label>
+            <Label htmlFor="time-format" className="text-slate-700 dark:text-slate-200">{t('settings.timeFormat')}</Label>
             <Select
               value={timeFormat}
               onValueChange={v => setTimeFormat(v as '24h' | '12h')}
             >
-              <SelectItem value="24h">24-hour</SelectItem>
-              <SelectItem value="12h">12-hour</SelectItem>
+              <SelectItem value="24h">{t('settings.timeFormat24')}</SelectItem>
+              <SelectItem value="12h">{t('settings.timeFormat12')}</SelectItem>
+            </Select>
+          </div>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="language" className="text-slate-700 dark:text-slate-200">{t('settings.language')}</Label>
+            <Select
+              value={language}
+              onValueChange={v => setLanguage(v as 'en' | 'fr')}
+            >
+              <SelectItem value="en">{t('settings.english')}</SelectItem>
+              <SelectItem value="fr">{t('settings.french')}</SelectItem>
             </Select>
           </div>
         </CardContent>
@@ -39,3 +51,4 @@ export default function Settings() {
     </div>
   );
 }
+

--- a/src/SettingsContext.tsx
+++ b/src/SettingsContext.tsx
@@ -1,11 +1,14 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
 type TimeFormat = '24h' | '12h';
+type Language = 'en' | 'fr';
 interface SettingsContextValue {
   darkMode: boolean;
   setDarkMode: (value: boolean) => void;
   timeFormat: TimeFormat;
   setTimeFormat: (format: TimeFormat) => void;
+  language: Language;
+  setLanguage: (lang: Language) => void;
 }
 
 const SettingsContext = createContext<SettingsContextValue | undefined>(undefined);
@@ -27,6 +30,14 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     return '24h';
   });
 
+  const [language, setLanguageState] = useState<Language>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('language');
+      return stored === 'fr' ? 'fr' : 'en';
+    }
+    return 'en';
+  });
+
   useEffect(() => {
     localStorage.setItem('darkMode', String(darkMode));
     if (darkMode) {
@@ -40,11 +51,16 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     localStorage.setItem('timeFormat', timeFormat);
   }, [timeFormat]);
 
+  useEffect(() => {
+    localStorage.setItem('language', language);
+  }, [language]);
+
   const setDarkMode = (value: boolean) => setDarkModeState(value);
   const setTimeFormat = (format: TimeFormat) => setTimeFormatState(format);
+  const setLanguage = (lang: Language) => setLanguageState(lang);
 
   return (
-    <SettingsContext.Provider value={{ darkMode, setDarkMode, timeFormat, setTimeFormat }}>
+    <SettingsContext.Provider value={{ darkMode, setDarkMode, timeFormat, setTimeFormat, language, setLanguage }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,182 @@
+import { useSettings } from './SettingsContext';
+import { enUS, fr } from 'date-fns/locale';
+
+type Lang = 'en' | 'fr';
+
+type Translations = Record<Lang, Record<string, any>>;
+
+const translations: Translations = {
+  en: {
+    settings: {
+      title: 'Settings',
+      darkMode: 'Dark mode',
+      timeFormat: 'Time format',
+      timeFormat24: '24-hour',
+      timeFormat12: '12-hour',
+      language: 'Language',
+      english: 'English',
+      french: 'French',
+    },
+    schedule: {
+      loading: 'Loading your schedule...',
+      tag: 'Daily Schedule',
+      title: 'Your Day Plan',
+      description: 'Plan your week and view each day with an intuitive schedule and clear visualizations',
+      entriesCountLabel: 'Schedule Entries',
+      searchPlaceholder: 'Search activities...',
+      searchButton: 'Search',
+      emptyTitle: 'Your Schedule Awaits',
+      emptyDescription: 'Use the selector above to create a timetable, then add your first entry in the Admin Panel.',
+    },
+    admin: {
+      tag: 'Admin Panel',
+      title: 'Schedule Control',
+      description: 'Add new items to your daily schedule. Each item will automatically position itself based on date.',
+      success: 'Schedule item added successfully!',
+      recentEntries: 'Recent Entries',
+      noEntries: 'No entries yet',
+      featureTitle: 'Intelligent Positioning',
+      featureDesc: 'Your schedule automatically sorts and positions entries by date, creating an easy-to-follow plan.',
+    },
+    entryForm: {
+      title: 'Add Schedule Item',
+      fields: {
+        title: 'Title',
+        titlePlaceholder: 'Enter event title...',
+        date: 'Date',
+        precision: 'Precision',
+        description: 'Description',
+        descriptionPlaceholder: 'Describe this scheduled activity...',
+      },
+      precision: {
+        year: 'Year',
+        month: 'Month',
+        day: 'Day',
+        hour: 'Hour',
+        minute: 'Minute',
+      },
+      submitting: 'Adding to Schedule...',
+      submit: 'Add to Schedule',
+    },
+    importEntries: {
+      title: 'Import JSON',
+      import: 'Import',
+      importing: 'Importing...'
+    },
+    timetableManager: {
+      selectPlaceholder: 'Select timetable',
+      newPlaceholder: 'New timetable',
+      create: 'Create',
+      delete: 'Delete',
+      deleteAll: 'Delete All',
+      deletingIn: 'Deleting in',
+      confirmNow: 'Confirm now',
+      cancel: 'Cancel',
+    },
+    calendarEditor: {
+      eventPrompt: 'Event title',
+      deleteConfirm: 'Delete this event?'
+    },
+    nav: {
+      schedule: 'Schedule',
+      admin: 'Admin Panel',
+      settings: 'Settings',
+      navigation: 'Navigation',
+    }
+  },
+  fr: {
+    settings: {
+      title: 'Paramètres',
+      darkMode: 'Mode sombre',
+      timeFormat: "Format de l'heure",
+      timeFormat24: '24 heures',
+      timeFormat12: '12 heures',
+      language: 'Langue',
+      english: 'Anglais',
+      french: 'Français',
+    },
+    schedule: {
+      loading: 'Chargement de votre emploi du temps...',
+      tag: 'Agenda quotidien',
+      title: 'Planifier votre journée',
+      description: 'Planifiez votre semaine et visualisez chaque jour avec un emploi du temps intuitif et des visualisations claires',
+      entriesCountLabel: "Entrées d'emploi du temps",
+      searchPlaceholder: 'Rechercher des activités...',
+      searchButton: 'Rechercher',
+      emptyTitle: 'Votre emploi du temps vous attend',
+      emptyDescription: "Utilisez le sélecteur ci-dessus pour créer un emploi du temps, puis ajoutez votre première entrée dans le panneau d’administration.",
+    },
+    admin: {
+      tag: "Panneau d'administration",
+      title: 'Contrôle du programme',
+      description: 'Ajoutez de nouveaux éléments à votre emploi du temps quotidien. Chaque élément se positionne automatiquement en fonction de la date.',
+      success: 'Élément ajouté avec succès !',
+      recentEntries: 'Entrées récentes',
+      noEntries: "Aucune entrée pour l'instant",
+      featureTitle: 'Positionnement intelligent',
+      featureDesc: "Votre emploi du temps trie et positionne automatiquement les entrées par date, pour un plan facile à suivre.",
+    },
+    entryForm: {
+      title: 'Ajouter un élément',
+      fields: {
+        title: 'Titre',
+        titlePlaceholder: "Entrez le titre de l'événement...",
+        date: 'Date',
+        precision: 'Précision',
+        description: 'Description',
+        descriptionPlaceholder: 'Décrivez cette activité...',
+      },
+      precision: {
+        year: 'Année',
+        month: 'Mois',
+        day: 'Jour',
+        hour: 'Heure',
+        minute: 'Minute',
+      },
+      submitting: 'Ajout en cours...',
+      submit: 'Ajouter au programme',
+    },
+    importEntries: {
+      title: 'Importer JSON',
+      import: 'Importer',
+      importing: 'Importation en cours...'
+    },
+    timetableManager: {
+      selectPlaceholder: "Sélectionner un emploi du temps",
+      newPlaceholder: 'Nouvel emploi du temps',
+      create: 'Créer',
+      delete: 'Supprimer',
+      deleteAll: 'Tout supprimer',
+      deletingIn: 'Suppression dans',
+      confirmNow: 'Confirmer maintenant',
+      cancel: 'Annuler',
+    },
+    calendarEditor: {
+      eventPrompt: "Titre de l'événement",
+      deleteConfirm: 'Supprimer cet événement ?'
+    },
+    nav: {
+      schedule: 'Agenda',
+      admin: "Panneau d'administration",
+      settings: 'Paramètres',
+      navigation: 'Navigation',
+    }
+  }
+};
+
+const dateLocales: Record<Lang, Locale> = { en: enUS, fr };
+
+export function useTranslation() {
+  const { language } = useSettings();
+  const t = (key: string): string => {
+    const parts = key.split('.');
+    let result: any = translations[language];
+    for (const p of parts) {
+      result = result?.[p];
+    }
+    return result ?? key;
+  };
+  return { t, locale: dateLocales[language], language };
+}
+
+export default translations;


### PR DESCRIPTION
## Summary
- introduce centralized i18n module with English/French strings and locale-aware formatter
- translate navigation, pages, and admin components so language choice affects entire UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ed1746ed0832091bc19a3015469ac