### PR TITLE
docs: clarify import template

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The file must specify a timetable and follow this structure:
 ```json
 {
   "timetable": { "name": "My Schedule" },
+  "timetableId": null,
   "entries": [
     {
       "title": "Event title",
@@ -55,6 +56,9 @@ The file must specify a timetable and follow this structure:
   ]
 }
 ```
+
+If `timetableId` is provided, entries will be imported into that existing timetable.
+Otherwise a new timetable will be created from the `timetable` name.
 
 An example file is provided at `import-example.json`.
 

--- a/import-example.json
+++ b/import-example.json
@@ -1,5 +1,6 @@
 {
   "timetable": { "name": "Sample Schedule" },
+  "timetableId": null,
   "entries": [
     {
       "title": "Started Job",


### PR DESCRIPTION
## Summary
- document optional `timetableId` in import JSON and README
- provide clearer example template for bulk entry import

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ed9a4bc9c832088115781c0c04c52