### PR TITLE
feat: add recurring entries and reminders

### DIFF
--- a/components/admin/EntryForm.tsx
+++ b/components/admin/EntryForm.tsx
@@ -15,18 +15,27 @@ export default function EntryForm({ onSubmit, isLoading }) {
     description: "",
     date: "",
     precision: "day",
+    recurrenceRule: "none",
+    reminderAt: "",
   });
   const { t } = useTranslation();
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    const { date, precision } = formData;
+    const { date, precision, reminderAt, recurrenceRule } = formData;
     let isoDate = "";
     if (precision === "year") isoDate = new Date(`${date}-01-01`).toISOString();
     else if (precision === "month") isoDate = new Date(`${date}-01`).toISOString();
     else isoDate = new Date(date).toISOString();
-    onSubmit({ ...formData, date: isoDate });
-    setFormData({ title: "", description: "", date: "", precision: "day" });
+    const isoReminder = reminderAt ? new Date(reminderAt).toISOString() : null;
+    const payload = {
+      ...formData,
+      date: isoDate,
+      reminderAt: isoReminder,
+      recurrenceRule: recurrenceRule === "none" ? null : recurrenceRule,
+    };
+    onSubmit(payload);
+    setFormData({ title: "", description: "", date: "", precision: "day", recurrenceRule: "none", reminderAt: "" });
   };
 
   const handleChange = (field, value) => {
@@ -103,6 +112,32 @@ export default function EntryForm({ onSubmit, isLoading }) {
                   <SelectItem value="minute">{t('entryForm.precision.minute')}</SelectItem>
                 </SelectContent>
               </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label className="text-sm font-semibold text-slate-700">Recurrence</Label>
+              <Select value={formData.recurrenceRule} onValueChange={(value) => handleChange("recurrenceRule", value)}>
+                <SelectTrigger className="border-slate-200 focus:border-amber-400 focus:ring-amber-400/20">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">None</SelectItem>
+                  <SelectItem value="daily">Daily</SelectItem>
+                  <SelectItem value="weekly">Weekly</SelectItem>
+                  <SelectItem value="monthly">Monthly</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="reminder" className="text-sm font-semibold text-slate-700">Reminder</Label>
+              <Input
+                id="reminder"
+                type="datetime-local"
+                value={formData.reminderAt}
+                onChange={(e) => handleChange("reminderAt", e.target.value)}
+                className="border-slate-200 focus:border-amber-400 focus:ring-amber-400/20"
+              />
             </div>
 
             <div className="space-y-2">

--- a/entities/TimelineEntry.ts
+++ b/entities/TimelineEntry.ts
@@ -4,6 +4,8 @@ export interface TimelineEntryType {
   description: string;
   date: string;
   precision: 'year' | 'month' | 'day' | 'hour' | 'minute';
+  recurrenceRule?: string | null;
+  reminderAt?: string | null;
   createdAt: string;
   timetableId: number;
 }
@@ -48,5 +50,25 @@ export class TimelineEntry {
   static async delete(id: number): Promise<void> {
     const res = await fetch(`${API_URL}/${id}`, { method: 'DELETE' });
     if (!res.ok) throw new Error('Failed to delete entry');
+  }
+
+  static async scheduleReminder(id: number, reminderAt: string | null): Promise<TimelineEntryType> {
+    const res = await fetch(`${API_URL}/${id}/reminder`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reminderAt })
+    });
+    if (!res.ok) throw new Error('Failed to schedule reminder');
+    return res.json();
+  }
+
+  static async generateRecurring(id: number, count: number): Promise<TimelineEntryType[]> {
+    const res = await fetch(`${API_URL}/${id}/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ count })
+    });
+    if (!res.ok) throw new Error('Failed to generate recurrence');
+    return res.json();
   }
 }

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -79,6 +79,21 @@ export default function Schedule() {
     }
   }, [entries]);
 
+  useEffect(() => {
+    const timers: NodeJS.Timeout[] = [];
+    for (const entry of entries) {
+      if (entry.reminderAt) {
+        const delay = new Date(entry.reminderAt).getTime() - Date.now();
+        if (delay > 0) {
+          timers.push(setTimeout(() => {
+            alert(`Reminder: ${entry.title}`);
+          }, delay));
+        }
+      }
+    }
+    return () => timers.forEach(t => clearTimeout(t));
+  }, [entries]);
+
   if (isLoading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-amber-50 dark:from-slate-900 dark:via-slate-900 dark:to-slate-800 flex items-center justify-center">

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,8 @@ model TimelineEntry {
   description String
   date        DateTime
   precision   String
+  recurrenceRule String?
+  reminderAt   DateTime?
   createdAt   DateTime  @default(now())
   timetable   Timetable @relation(fields: [timetableId], references: [id])
   timetableId Int

--- a/server/index.js
+++ b/server/index.js
@@ -66,13 +66,21 @@ app.get('/api/entries', async (req, res) => {
 });
 
 app.post('/api/entries', async (req, res) => {
-  const { title, description, date, precision, timetableId } = req.body;
+  const { title, description, date, precision, timetableId, recurrenceRule, reminderAt } = req.body;
   if (!title || !date || !precision || !timetableId) {
     res.status(400).json({ error: 'Missing fields' });
     return;
   }
   const entry = await prisma.timelineEntry.create({
-    data: { title, description, date: new Date(date), precision, timetableId }
+    data: {
+      title,
+      description,
+      date: new Date(date),
+      precision,
+      timetableId,
+      recurrenceRule: recurrenceRule || null,
+      reminderAt: reminderAt ? new Date(reminderAt) : null,
+    }
   });
   res.json(entry);
 });
@@ -93,6 +101,63 @@ app.post('/api/entries/bulk', async (req, res) => {
         date: new Date(e.date),
         precision: e.precision,
         timetableId,
+        recurrenceRule: e.recurrenceRule || null,
+        reminderAt: e.reminderAt ? new Date(e.reminderAt) : null,
+      }
+    });
+    created.push(entry);
+  }
+  res.json(created);
+});
+
+app.post('/api/entries/:id/reminder', async (req, res) => {
+  const id = Number(req.params.id);
+  const { reminderAt } = req.body;
+  const entry = await prisma.timelineEntry.update({
+    where: { id },
+    data: { reminderAt: reminderAt ? new Date(reminderAt) : null }
+  });
+  res.json(entry);
+});
+
+function getNextDate(date, rule) {
+  const d = new Date(date);
+  switch (rule) {
+    case 'daily':
+      d.setDate(d.getDate() + 1);
+      break;
+    case 'weekly':
+      d.setDate(d.getDate() + 7);
+      break;
+    case 'monthly':
+      d.setMonth(d.getMonth() + 1);
+      break;
+    default:
+      throw new Error('Unsupported recurrence rule');
+  }
+  return d;
+}
+
+app.post('/api/entries/:id/generate', async (req, res) => {
+  const id = Number(req.params.id);
+  const { count = 1 } = req.body;
+  const base = await prisma.timelineEntry.findUnique({ where: { id } });
+  if (!base || !base.recurrenceRule) {
+    res.status(400).json({ error: 'Entry not found or missing recurrence rule' });
+    return;
+  }
+  const created = [];
+  let date = new Date(base.date);
+  for (let i = 0; i < count; i++) {
+    date = getNextDate(date, base.recurrenceRule);
+    const entry = await prisma.timelineEntry.create({
+      data: {
+        title: base.title,
+        description: base.description,
+        date,
+        precision: base.precision,
+        timetableId: base.timetableId,
+        recurrenceRule: base.recurrenceRule,
       }
     });
     created.push(entry);
@@ -110,3 +175,21 @@ const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => {
   console.log(`API server listening on port ${PORT}`);
 });
+
+async function checkReminders() {
+  const now = new Date();
+  const due = await prisma.timelineEntry.findMany({
+    where: {
+      reminderAt: { lte: now }
+    }
+  });
+  for (const entry of due) {
+    console.log(`Reminder: ${entry.title} at ${entry.reminderAt}`);
+    await prisma.timelineEntry.update({
+      where: { id: entry.id },
+      data: { reminderAt: null }
+    });
+  }
+}
+
+setInterval(checkReminders, 60000);


### PR DESCRIPTION
## Summary
- add recurrence and reminder fields to timeline entries
- expose reminder scheduling and recurrence generation endpoints
- capture recurrence and reminder options in client and schedule notifications

## Testing
- `npx prisma generate`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688eef1b5edc8320ba6f17fc6d1f959f