### PR TITLE
Enable editing of schedule entries

### DIFF
--- a/components/admin/EntryForm.tsx
+++ b/components/admin/EntryForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -9,7 +9,7 @@ import { Plus, Sparkles } from "lucide-react";
 import { motion } from "framer-motion";
 import { useTranslation } from "@/src/i18n";
 
-export default function EntryForm({ onSubmit, isLoading }) {
+export default function EntryForm({ onSubmit, isLoading, initialData, onCancel }) {
   const [formData, setFormData] = useState({
     title: "",
     description: "",
@@ -17,6 +17,36 @@ export default function EntryForm({ onSubmit, isLoading }) {
     precision: "day",
   });
   const { t } = useTranslation();
+
+  useEffect(() => {
+    if (initialData) {
+      const d = new Date(initialData.date);
+      let formatted = "";
+      switch (initialData.precision) {
+        case "year":
+          formatted = d.getFullYear().toString();
+          break;
+        case "month":
+          formatted = d.toISOString().slice(0, 7);
+          break;
+        case "day":
+          formatted = d.toISOString().slice(0, 10);
+          break;
+        case "hour":
+          formatted = d.toISOString().slice(0, 13);
+          break;
+        case "minute":
+          formatted = d.toISOString().slice(0, 16);
+          break;
+      }
+      setFormData({
+        title: initialData.title || "",
+        description: initialData.description || "",
+        date: formatted,
+        precision: initialData.precision || "day",
+      });
+    }
+  }, [initialData]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -26,7 +56,11 @@ export default function EntryForm({ onSubmit, isLoading }) {
     else if (precision === "month") isoDate = new Date(`${date}-01`).toISOString();
     else isoDate = new Date(date).toISOString();
     onSubmit({ ...formData, date: isoDate });
-    setFormData({ title: "", description: "", date: "", precision: "day" });
+    if (initialData) {
+      onCancel?.();
+    } else {
+      setFormData({ title: "", description: "", date: "", precision: "day" });
+    }
   };
 
   const handleChange = (field, value) => {
@@ -119,23 +153,34 @@ export default function EntryForm({ onSubmit, isLoading }) {
               />
             </div>
 
-            <Button
-              type="submit"
-              disabled={isLoading}
-              className="w-full bg-gradient-to-r from-slate-800 to-slate-900 hover:from-slate-900 hover:to-black text-white shadow-lg hover:shadow-xl transition-all duration-300 py-3"
-            >
-              {isLoading ? (
-                <div className="flex items-center gap-2">
-                  <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                  {t('entryForm.submitting')}
-                </div>
-              ) : (
-                <>
-                  <Plus className="w-5 h-5 mr-2" />
-                  {t('entryForm.submit')}
-                </>
+            <div className="flex gap-2">
+              <Button
+                type="submit"
+                disabled={isLoading}
+                className="flex-1 bg-gradient-to-r from-slate-800 to-slate-900 hover:from-slate-900 hover:to-black text-white shadow-lg hover:shadow-xl transition-all duration-300 py-3"
+              >
+                {isLoading ? (
+                  <div className="flex items-center gap-2">
+                    <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                    {t('entryForm.submitting')}
+                  </div>
+                ) : (
+                  <>
+                    <Plus className="w-5 h-5 mr-2" />
+                    {initialData ? t('entryForm.update') : t('entryForm.submit')}
+                  </>
+                )}
+              </Button>
+              {onCancel && (
+                <Button
+                  type="button"
+                  onClick={onCancel}
+                  className="flex-1 bg-slate-200 text-slate-800 hover:bg-slate-300 shadow-lg hover:shadow-xl transition-all duration-300 py-3"
+                >
+                  {t('timetableManager.cancel')}
+                </Button>
               )}
-            </Button>
+            </div>
           </form>
         </CardContent>
       </Card>

--- a/components/timeline/TimelineEntry.tsx
+++ b/components/timeline/TimelineEntry.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { motion } from "framer-motion";
 import { Card, CardContent } from "@/components/ui/card";
-import { Calendar } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Calendar, Pencil } from "lucide-react";
 import { format, parseISO } from "date-fns";
 import { useSettings } from "@/src/SettingsContext";
 import { useTranslation } from "@/src/i18n";
 
-export default function TimelineEntry({ entry, position, isLeft }) {
+export default function TimelineEntry({ entry, position, isLeft, onEdit }) {
   const { timeFormat } = useSettings();
   const { locale } = useTranslation();
 
@@ -41,7 +42,15 @@ export default function TimelineEntry({ entry, position, isLeft }) {
       style={{ top: `${position * 180 + 60}px` }}
     >
       <Card className="bg-white/90 backdrop-blur-sm border-slate-200/60 hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 dark:bg-slate-800/90 dark:border-slate-700/60">
-        <CardContent className="p-6">
+        <CardContent className="p-6 relative">
+          {onEdit && (
+            <Button
+              onClick={() => onEdit(entry)}
+              className="absolute top-2 right-2 p-1 bg-transparent border-none hover:bg-slate-100"
+            >
+              <Pencil className="w-4 h-4" />
+            </Button>
+          )}
           <div className="flex items-start gap-4">
             <div className="w-12 h-12 rounded-xl bg-gradient-to-r from-blue-500 to-indigo-500 flex items-center justify-center shadow-lg flex-shrink-0">
               <Calendar className="w-6 h-6 text-white" />

--- a/entities/TimelineEntry.ts
+++ b/entities/TimelineEntry.ts
@@ -45,6 +45,16 @@ export class TimelineEntry {
     return res.json();
   }
 
+  static async update(id: number, data: Pick<TimelineEntryType, 'title' | 'description' | 'date' | 'precision'>): Promise<TimelineEntryType> {
+    const res = await fetch(`${API_URL}/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    if (!res.ok) throw new Error('Failed to update entry');
+    return res.json();
+  }
+
   static async delete(id: number): Promise<void> {
     const res = await fetch(`${API_URL}/${id}`, { method: 'DELETE' });
     if (!res.ok) throw new Error('Failed to delete entry');

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -7,6 +7,7 @@ import TimelineEntryComponent from "../components/timeline/TimelineEntry";
 import TimelineLine from "../components/timeline/TimelineLine";
 import { Calendar, TrendingUp } from "lucide-react";
 import TimetableManager from "../components/admin/TimetableManager";
+import EntryForm from "../components/admin/EntryForm";
 import { useTranslation } from "@/src/i18n";
 
 export default function Schedule() {
@@ -17,6 +18,8 @@ export default function Schedule() {
   const [scrollTop, setScrollTop] = useState(0);
   const [containerHeight, setContainerHeight] = useState(0);
   const [timetableId, setTimetableId] = useState<number | null>(null);
+  const [editingEntry, setEditingEntry] = useState(null);
+  const [isSaving, setIsSaving] = useState(false);
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -42,6 +45,19 @@ export default function Schedule() {
       console.error("Error loading schedule entries:", error);
     }
     setIsLoading(false);
+  };
+
+  const handleUpdate = async (formData) => {
+    if (!editingEntry) return;
+    setIsSaving(true);
+    try {
+      await TimelineEntry.update(editingEntry.id, formData);
+      setEditingEntry(null);
+      await loadEntries();
+    } catch (error) {
+      console.error('Error updating entry:', error);
+    }
+    setIsSaving(false);
   };
 
   const searchEntries = async (query: string) => {
@@ -171,12 +187,23 @@ export default function Schedule() {
                   entry={entry}
                   position={startIndex + index}
                   isLeft={(startIndex + index) % 2 === 0}
+                  onEdit={setEditingEntry}
                 />
               ))}
             </div>
           </div>
         )}
       </div>
+      {editingEntry && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <EntryForm
+            onSubmit={handleUpdate}
+            isLoading={isSaving}
+            initialData={editingEntry}
+            onCancel={() => setEditingEntry(null)}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/server/index.js
+++ b/server/index.js
@@ -100,6 +100,20 @@ app.post('/api/entries/bulk', async (req, res) => {
   res.json(created);
 });
 
+app.put('/api/entries/:id', async (req, res) => {
+  const id = Number(req.params.id);
+  const { title, description, date, precision } = req.body;
+  if (!title || !date || !precision) {
+    res.status(400).json({ error: 'Missing fields' });
+    return;
+  }
+  const entry = await prisma.timelineEntry.update({
+    where: { id },
+    data: { title, description, date: new Date(date), precision }
+  });
+  res.json(entry);
+});
+
 app.delete('/api/entries/:id', async (req, res) => {
   const id = Number(req.params.id);
   await prisma.timelineEntry.delete({ where: { id } });

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -57,6 +57,7 @@ const translations: Translations = {
       },
       submitting: 'Adding to Schedule...',
       submit: 'Add to Schedule',
+      update: 'Update Entry',
     },
     importEntries: {
       title: 'Import JSON',
@@ -135,6 +136,7 @@ const translations: Translations = {
       },
       submitting: 'Ajout en cours...',
       submit: 'Ajouter au programme',
+      update: 'Mettre à jour',
     },
     importEntries: {
       title: 'Importer JSON',


### PR DESCRIPTION
## Summary
- allow editing entries via new `PUT /api/entries/:id` endpoint
- expose `TimelineEntry.update` client helper
- reuse EntryForm for editing and show edit buttons in schedule list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688eef2796808320a5f6750831412962