### PR TITLE
Allow unauthenticated GET requests

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -33,7 +33,7 @@ app.post('/api/login', async (req, res) => {
 });
 
 app.use('/api', (req, res, next) => {
-  if (req.path === '/login') return next();
+  if (req.path === '/login' || req.method === 'GET') return next();
   const authHeader = req.headers.authorization;
   if (!authHeader) {
     res.status(401).json({ error: 'Unauthorized' });


### PR DESCRIPTION
## Summary
- allow unauthenticated GET requests to /api endpoints to prevent 401 errors on public pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f0763ee54832092a7a7733dda7330